### PR TITLE
feat: CMS admin management — listagem e criação de administradores

### DIFF
--- a/docs/.squads/sessions/portal-nexora/architecture.md
+++ b/docs/.squads/sessions/portal-nexora/architecture.md
@@ -1,442 +1,171 @@
-# CMS — Arquitetura do Fluxo de Autenticação e Painel Administrativo
+# Decisão Arquitetural: Criar Novos Administradores (CMS)
 
-> Produzido por Ana Arquitetura (ana-arquitetura-fe) — Squad frontend-001  
-> Data: 2026-04-30 | Status: Aprovado para implementação
-
----
-
-## 1. Entendimento da Task
-
-O objetivo é criar o fluxo completo de acesso ao CMS do Portal Nexora: autenticação via Supabase Auth (login/logout/cadastro), proteção de rotas, sidebar/navbar do painel e schema do banco para múltiplos perfis de acesso (admin, content_creator, professor). O CMS roda sob o route group `(cms)` e deve ser completamente isolado do site público.
+**Data:** 2026-04-30
+**Agent:** Ana Arquitetura (ana-arquitetura-fe)
+**Status:** Aprovado para implementação
 
 ---
 
-## 2. Estrutura de Arquivos e Pastas
+## Entendimento da Task
 
-```
-src/
-├── app/
-│   ├── (publics)/                         # site público (existente)
-│   ├── (cms)/                             # route group CMS — não gera segmento de URL
-│   │   ├── layout.tsx                     # CMS layout — valida sessão, renderiza Sidebar
-│   │   ├── login/
-│   │   │   ├── page.tsx                   # Server Component — sem lógica, sem hooks
-│   │   │   └── _features/login/
-│   │   │       ├── schema.ts              # Zod schema do formulário de login
-│   │   │       ├── view.tsx               # Client Component — formulário RHF
-│   │   │       └── actions.ts             # Server Actions — signIn, signOut
-│   │   ├── register/
-│   │   │   ├── page.tsx
-│   │   │   └── _features/register/
-│   │   │       ├── schema.ts
-│   │   │       ├── view.tsx
-│   │   │       └── actions.ts
-│   │   └── dashboard/
-│   │       ├── page.tsx                   # Dashboard principal (Server Component)
-│   │       └── _features/dashboard/
-│   │           └── view.tsx               # Conteúdo do dashboard
-│   ├── globals.css
-│   ├── favicon.ico
-│   └── layout.tsx                         # Root layout (existente)
-│
-├── components/
-│   ├── cms/                               # Componentes exclusivos do CMS
-│   │   ├── Sidebar/
-│   │   │   ├── index.tsx                  # Server Component — lê sessão e renderiza
-│   │   │   ├── SidebarNav.tsx             # Client Component — links ativos com usePathname
-│   │   │   └── SidebarUserMenu.tsx        # Client Component — avatar + logout
-│   │   ├── TopBar/
-│   │   │   └── index.tsx                  # Client Component — título da página + ações
-│   │   └── CMSShell.tsx                   # Layout shell: Sidebar + área de conteúdo
-│   ├── layout/                            # Header/Footer públicos (existente)
-│   └── ui/                               # Shadcn (existente)
-│
-├── lib/
-│   ├── utils.ts                           # cn() (existente)
-│   └── supabase/
-│       ├── client.ts                      # createBrowserClient — uso em Client Components
-│       ├── server.ts                      # createServerClient — uso em Server Components e Actions
-│       └── middleware.ts                  # createServerClient para uso no proxy
-│
-└── middleware.ts                          # Proxy Next.js — proteção de rotas CMS
-```
-
-> **Nota de rota:** O route group `(cms)` isola o CMS sem prefixar URLs. As rotas resultantes são `/login`, `/register` e `/dashboard`. Se houver conflito com rotas públicas que usem os mesmos slugs, o route group deverá ser renomeado para `(cms-area)` e as rotas prefixadas: `/cms/login`, `/cms/dashboard`.
->
-> **Decisão adotada aqui:** Usar prefixo `/cms/*` via route group `(cms)` + pasta `cms/` dentro de `(cms)`. Rotas resultantes: `/cms/login`, `/cms/register`, `/cms/dashboard`.  
-> Estrutura revisada:
-
-```
-src/app/
-└── (cms)/
-    └── cms/                               # gera o prefixo /cms na URL
-        ├── login/page.tsx                 → /cms/login
-        ├── register/page.tsx              → /cms/register
-        └── dashboard/page.tsx             → /cms/dashboard
-```
+Formulário dentro do dashboard CMS que permite a um admin autenticado criar uma nova conta de usuário administrativo — escolhendo nome, e-mail, senha temporária e role (admin, content_creator, professor). Diferente de `/cms/register` (auto-cadastro de acesso livre), este fluxo é **protegido** e usa a Supabase Admin API (`auth.admin.createUser`) via service role key.
 
 ---
 
-## 3. Decisões de Estado
+## Contexto Existente
 
-| Contexto | Decisão | Justificativa |
+O CMS já possui:
+- `/cms/login` e `/cms/register` — auto-cadastro público
+- `/cms/dashboard` — painel protegido por `proxy.ts` + `dashboard/layout.tsx`
+- Tabela `admin_profiles` com campo `role: 'admin' | 'content_creator' | 'professor'`
+- `CMSShell` com Sidebar e TopBar
+
+A nova feature se encaixa dentro do dashboard existente, sem tocar nas rotas de auth.
+
+---
+
+## Estrutura de Componentes
+
+```
+src/app/(cms)/cms/dashboard/
+└── admins/
+    └── novo/
+        ├── page.tsx
+        └── _features/
+            └── NovoAdmin/
+                ├── view.tsx
+                ├── viewModel.tsx
+                ├── schema.ts
+                └── actions.ts
+```
+
+> `_features/` com `_` prefix é invisível ao App Router — não gera rota.
+> Padrão conforme [DECISÃO CRÍTICA] em memories.md de 2026-04-25.
+
+---
+
+## Decisões de Estado
+
+| Estado | Tipo | Justificativa |
 |---|---|---|
-| Dados da sessão autenticada | Lidos via `createServerClient` no Server Component/layout | Sem estado global no cliente — evita prop drilling e hydration mismatch |
-| Formulários de login/cadastro | `useActionState` + Server Actions | Padrão Next.js 16 App Router; sem fetch manual; sem `useState` para campos |
-| Rota ativa na Sidebar | `usePathname()` no `SidebarNav` (Client Component) | API de navegação só disponível no cliente |
-| Logout | Server Action com `supabase.auth.signOut()` + `redirect()` | Garante limpeza de cookies pelo servidor |
-| Dados do usuário logado para Sidebar | Passados como props do Server Component pai | Evita criar Context desnecessário; o volume de dados é mínimo (nome, role, avatar) |
+| Dados do formulário | React Hook Form | Obrigatório por ADR-004; sem useState por campo |
+| Erros de validação client | RHF + Zod resolver | Validação em tempo real no cliente |
+| Erros de servidor / feedback | `useActionState` | Padrão App Router; mantém estado do Server Action |
+| Loading do submit | `isPending` do `useActionState` | Nativo, sem estado extra |
+| Role selecionado | RHF field `role` | Campo controlado pelo form, sem estado separado |
 
 ---
 
-## 4. Contratos dos Componentes Principais
+## Contratos dos Componentes
 
 ```typescript
-// src/lib/supabase/types.ts
-
-type AdminRole = 'admin' | 'content_creator' | 'professor'
-
-type AdminProfile = {
-  id: string
-  user_id: string
-  full_name: string
-  role: AdminRole
-  avatar_url: string | null
-  created_at: string
-}
-
-type SessionUser = {
-  id: string
-  email: string
-  profile: AdminProfile
-}
-```
-
-```typescript
-// src/components/cms/Sidebar/index.tsx
-type SidebarProps = {
-  user: SessionUser
-}
-
-// src/components/cms/Sidebar/SidebarNav.tsx
-type NavItem = {
-  label: string
-  href: string
-  icon: React.ComponentType<{ className?: string }>
-}
-
-type SidebarNavProps = {
-  items: NavItem[]
-}
-
-// src/components/cms/Sidebar/SidebarUserMenu.tsx
-type SidebarUserMenuProps = {
-  user: SessionUser
-}
-
-// src/components/cms/CMSShell.tsx
-type CMSShellProps = {
-  user: SessionUser
-  children: React.ReactNode
-}
-```
-
-```typescript
-// src/app/(cms)/cms/login/_features/login/schema.ts
+// schema.ts
 import { z } from 'zod'
 
-export const loginSchema = z.object({
-  email: z.email({ error: 'Email inválido' }),
-  password: z.string().min(8, { error: 'Mínimo 8 caracteres' }),
-})
+export const novoAdminSchema = z
+  .object({
+    full_name: z.string().min(2, 'Nome deve ter no mínimo 2 caracteres'),
+    email: z.string().email('E-mail inválido'),
+    password: z.string().min(8, 'Senha deve ter no mínimo 8 caracteres'),
+    confirm_password: z.string(),
+    role: z.enum(['admin', 'content_creator', 'professor'], {
+      error: 'Role inválido',
+    }),
+  })
+  .refine((data) => data.password === data.confirm_password, {
+    message: 'As senhas não coincidem',
+    path: ['confirm_password'],
+  })
 
-export type LoginFormData = z.infer<typeof loginSchema>
+export type NovoAdminFormData = z.infer<typeof novoAdminSchema>
 ```
 
 ```typescript
-// src/app/(cms)/cms/register/_features/register/schema.ts
-import { z } from 'zod'
-
-export const registerSchema = z.object({
-  full_name: z.string().min(2, { error: 'Nome obrigatório' }),
-  email: z.email({ error: 'Email inválido' }),
-  password: z.string().min(8, { error: 'Mínimo 8 caracteres' }),
-  role: z.enum(['admin', 'content_creator', 'professor']),
-})
-
-export type RegisterFormData = z.infer<typeof registerSchema>
+// viewModel.tsx — contrato de retorno
+type NovoAdminViewModel = {
+  form: UseFormReturn<NovoAdminFormData>
+  formAction: (payload: FormData) => void
+  isPending: boolean
+  state: ActionState
+}
 ```
 
 ```typescript
-// Tipo do estado de Server Actions (useActionState)
-type ActionState = {
-  errors?: Record<string, string[]>
-  message?: string
-} | undefined
+// actions.ts — assinatura do Server Action
+async function criarAdmin(
+  _prevState: ActionState,
+  formData: FormData
+): Promise<ActionState>
 ```
 
 ---
 
-## 5. Schema Supabase
+## ADR-FE-001 — Admin API vs signUp para criação interna de contas
 
-### SQL — tabela `profiles`
+**Contexto:** `supabase.auth.signUp()` envia e-mail de confirmação e não permite definir role no momento da criação. O dashboard precisa criar contas sem confirmação e com role explícito.
 
-```sql
--- Executar no SQL Editor do Supabase
--- Depende da tabela auth.users gerenciada pelo Supabase Auth
+**Decisão:** Usar `supabase.auth.admin.createUser()` no Server Action, com `email_confirm: true`. Inserir profile em `admin_profiles` com o role escolhido em seguida.
 
-create type public.admin_role as enum (
-  'admin',
-  'content_creator',
-  'professor'
-);
+**Alternativas rejeitadas:**
+- `signUp()` — envia e-mail de confirmação, sem controle de role imediato
 
-create table public.profiles (
-  id          uuid primary key default gen_random_uuid(),
-  user_id     uuid not null references auth.users(id) on delete cascade,
-  full_name   text not null,
-  role        public.admin_role not null default 'content_creator',
-  avatar_url  text,
-  created_at  timestamptz not null default now(),
-  updated_at  timestamptz not null default now(),
-
-  constraint profiles_user_id_unique unique (user_id)
-);
-
--- RLS obrigatório
-alter table public.profiles enable row level security;
-
--- Admins veem todos os profiles
-create policy "admins_read_all_profiles"
-  on public.profiles for select
-  using (
-    exists (
-      select 1 from public.profiles p
-      where p.user_id = auth.uid()
-        and p.role = 'admin'
-    )
-  );
-
--- Usuário lê seu próprio profile
-create policy "user_read_own_profile"
-  on public.profiles for select
-  using (user_id = auth.uid());
-
--- Apenas admins criam profiles de outros usuários via service role
--- Inserção via service role no Server Action de registro (sem RLS bypass no cliente)
-
--- Trigger para atualizar updated_at
-create or replace function public.update_updated_at()
-returns trigger language plpgsql as $$
-begin
-  new.updated_at = now();
-  return new;
-end;
-$$;
-
-create trigger profiles_updated_at
-  before update on public.profiles
-  for each row execute function public.update_updated_at();
-```
-
-### Variáveis de Ambiente necessárias
-
-```bash
-# .env.local
-NEXT_PUBLIC_SUPABASE_URL=https://xxxx.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...          # cliente browser
-SUPABASE_SERVICE_ROLE_KEY=eyJ...              # NUNCA expor ao cliente
-```
+**Consequências:**
+- ✅ Conta ativa imediatamente, sem e-mail pendente
+- ✅ Role definido no momento da criação
+- ✅ Service role key fica 100% server-side
+- ⚠ Requer `SUPABASE_SERVICE_ROLE_KEY` em `.env.local` — nunca expor ao cliente
+- ⚠ Criar `createAdminClient()` separado em `src/lib/supabase/admin.ts`
 
 ---
 
-## 6. ADRs
+## ADR-FE-002 — Separação View / ViewModel (ADR-004 aplicado)
 
-### ADR-008 — Estratégia de Auth: Supabase SSR via `@supabase/ssr`
+**Contexto:** Features CMS existentes (`/cms/register`, `/cms/login`) têm lógica misturada em `view.tsx`, sem `viewModel.tsx`. A nova feature deve seguir ADR-004 corretamente.
 
-**Data:** 2026-04-30 | **Status:** Aceita
+**Decisão:** Criar `viewModel.tsx` separado. Não refatorar os existentes (fora do escopo).
 
-**Contexto:** O Supabase Auth pode ser usado de três formas: (a) client-only com `@supabase/supabase-js` + `localStorage`; (b) `@supabase/auth-helpers-nextjs` (depreciado); (c) `@supabase/ssr` com cookies.
-
-**Decisão:** Usar `@supabase/ssr` com dois clients distintos:
-- `createBrowserClient` → Client Components (leitura de sessão no cliente)
-- `createServerClient` → Server Components, Server Actions e Proxy (leitura e escrita de cookies)
-
-**Trade-offs:**
-- ✅ Sessão disponível no servidor antes do render — sem flicker de autenticação
-- ✅ Cookies HttpOnly gerenciados pelo Supabase — sem exposição de tokens no `localStorage`
-- ✅ Compatível com Next.js App Router e Proxy (Node.js runtime)
-- ❌ Requer dois clients distintos — mais boilerplate
-- ❌ `@supabase/ssr` é o pacote correto; `@supabase/auth-helpers-nextjs` está depreciado e NÃO deve ser usado
-
-**Dependências a instalar:**
-```bash
-npm install @supabase/supabase-js @supabase/ssr
-```
+**Consequências:**
+- ✅ `view.tsx` contém apenas JSX + Shadcn
+- ✅ `viewModel.tsx` encapsula `useActionState`, `useForm`, handlers
+- ✅ Serve de referência para refatoração futura dos existentes
+- ⚠ Inconsistência momentânea com features antigas — intencional
 
 ---
 
-### ADR-009 — Estrutura do Route Group CMS
+## Pontos de Atenção para o Dev
 
-**Data:** 2026-04-30 | **Status:** Aceita
+1. **`createAdminClient()`** — usa `SUPABASE_SERVICE_ROLE_KEY`, sem cookie handling. Criar em `src/lib/supabase/admin.ts`, diferente de `createClient()`.
 
-**Contexto:** O CMS precisa de layout próprio (com Sidebar) sem contaminar o layout do site público.
+2. **Campo `role` com Shadcn `<Select>`** — não é input nativo; usar `Controller` do RHF, não `register`.
 
-**Decisão:** Route group `(cms)` com pasta `cms/` interna, gerando rotas `/cms/*`. O layout `(cms)/layout.tsx` envolve apenas as rotas do CMS.
+3. **`cn()` obrigatório em todo `className`** — ADR-007, sem exceção.
 
-**Trade-offs:**
-- ✅ Isolamento total de layout entre site público e CMS
-- ✅ Prefixo `/cms` semânticamente claro nas URLs
-- ✅ `page.tsx` dentro de `(cms)/cms/login/` → rota `/cms/login` sem segmento extra do route group
-- ❌ Nesting duplo `(cms)/cms/` é contra-intuitivo — documentar para o time
+4. **`type` em vez de `interface`** — ADR-005. `NovoAdminFormData` derivado via `z.infer<>`.
 
-**Alternativa rejeitada:** Route group `(cms)` diretamente com `login/page.tsx` → rota `/login` colide com possível página de login futuro do site público.
+5. **Comportamento pós-sucesso** — redirecionar para `/cms/dashboard` após criação (listagem de admins fora do escopo desta task). O Server Action chama `redirect('/cms/dashboard')`.
+
+6. **Zod v4** — mensagens de erro como segundo arg string, não objeto `{ message }`. Confirmar versão instalada.
 
 ---
 
-### ADR-010 — Proteção de Rotas: Proxy (middleware.ts) como camada primária
+## Arquivos a Criar/Modificar
 
-**Data:** 2026-04-30 | **Status:** Aceita
-
-**Contexto:** Duas opções para proteger `/cms/*`:  
-(a) Verificar sessão no `layout.tsx` do CMS  
-(b) Usar o Proxy (`middleware.ts`) para redirecionar antes do render
-
-**Decisão:** Proxy (`src/middleware.ts`) como camada primária + verificação no layout como camada secundária.
-
-O Proxy faz verificação otimista lendo o cookie de sessão do Supabase (sem query ao banco). O layout faz verificação definitiva chamando `supabase.auth.getUser()`.
-
-```
-Request → Proxy (cookie check) → Layout (getUser()) → Page
-```
-
-**Trade-offs:**
-- ✅ Proxy evita render de páginas protegidas para usuários não autenticados
-- ✅ Layout como segunda linha de defesa — não depende apenas do cookie
-- ✅ Proxy não bloqueia rotas públicas (`/`, `/eventos`, etc.)
-- ❌ Lógica de auth em dois lugares — manter sincronizado
-- ❌ Proxy roda em todo request — manter lógica mínima (só leitura de cookie, sem DB)
-
-**Alternativa rejeitada:** Layout-only check — renderiza a página no servidor antes de redirecionar, causando flash e potencial leak de dados.
-
----
-
-### ADR-011 — Formulários CMS: React Hook Form + Zod + useActionState
-
-**Data:** 2026-04-30 | **Status:** Aceita
-
-**Contexto:** Formulários de login e cadastro precisam de validação client-side e server-side. Zod e RHF não estão instalados no projeto.
-
-**Decisão:** Instalar Zod e React Hook Form. Usar o padrão:
-- Schema Zod em `schema.ts` — fonte única de validação
-- RHF com `resolver` Zod para validação client-side em tempo real
-- `useActionState` para receber erros do Server Action
-- Server Action valida com o mesmo schema Zod antes de chamar Supabase
-
-**Dependências a instalar:**
-```bash
-npm install zod react-hook-form @hookform/resolvers
-```
-
-**Trade-offs:**
-- ✅ Validação consistente client e server com o mesmo schema
-- ✅ Sem `useState` para campos — conforme regra crítica do projeto
-- ✅ `type LoginFormData = z.infer<typeof loginSchema>` — sem duplicação de tipos
-- ❌ Mais dependências no projeto
-- ❌ RHF é Client Component — `view.tsx` precisa de `"use client"`
-
----
-
-## 7. Pontos de Atenção para o Dev
-
-1. **`@supabase/auth-helpers-nextjs` está depreciado** — usar exclusivamente `@supabase/ssr`. Qualquer exemplo da internet que use `createClientComponentClient` ou `createServerComponentClient` está desatualizado.
-
-2. **Proxy vs Middleware nomenclatura:** No Next.js 16, o arquivo é `middleware.ts` mas a doc interna chama de "Proxy". O arquivo fica na raiz do projeto (`src/middleware.ts`), não dentro de `app/`.
-
-3. **`cookies()` é assíncrono no Next.js 16** — sempre `await cookies()`, não `cookies()` síncrono.
-
-4. **`createServerClient` precisa de handler de cookies** — o server client do `@supabase/ssr` requer que você passe `get`/`set`/`remove` de cookies manualmente. Os três contextos (Server Component, Server Action, Proxy) têm implementações ligeiramente diferentes porque o objeto `cookies()` do Next.js se comporta diferente em cada contexto.
-
-5. **Inserção de profile após cadastro** — após `supabase.auth.signUp()`, inserir o registro em `public.profiles` usando o `service role client` (server-side) para contornar a RLS de inserção.
-
-6. **Login split-layout desktop-first** — o `view.tsx` do login usa grid `lg:grid-cols-2`. Em mobile, apenas o formulário é exibido; o painel com a logo é oculto com `hidden lg:flex`.
-
-7. **`SidebarNav` e `usePathname`** — `usePathname` só funciona em Client Components. O `SidebarNav` deve ter `"use client"` no topo. O `Sidebar/index.tsx` pai permanece Server Component e passa os itens como prop.
-
-8. **Zod v4 breaking change** — A versão atual do Zod usa `z.string().min(n, { error: '...' })` em vez de `{ message: '...' }`. Confirmar a versão instalada antes de escrever schemas.
-
-9. **`page.tsx` nunca recebe props de sessão** — a sessão é lida no `layout.tsx` (Server Component) e passada via props para o `CMSShell`, que repassa para `Sidebar` e `TopBar`. `page.tsx` permanece sem nenhuma lógica de auth.
-
----
-
-## 8. Arquivos a Modificar/Criar
-
-### Criar (novos)
+### Criar
 
 | Arquivo | Descrição |
 |---|---|
-| `src/middleware.ts` | Proxy — proteção de rotas `/cms/*` |
-| `src/lib/supabase/client.ts` | `createBrowserClient` |
-| `src/lib/supabase/server.ts` | `createServerClient` para Server Components/Actions |
-| `src/lib/supabase/middleware.ts` | `createServerClient` para uso no Proxy |
-| `src/lib/supabase/types.ts` | `AdminRole`, `AdminProfile`, `SessionUser` |
-| `src/app/(cms)/layout.tsx` | Layout CMS — verifica sessão, renderiza CMSShell |
-| `src/app/(cms)/cms/login/page.tsx` | Server Component — sem lógica |
-| `src/app/(cms)/cms/login/_features/login/schema.ts` | Zod schema login |
-| `src/app/(cms)/cms/login/_features/login/view.tsx` | Client Component — formulário RHF |
-| `src/app/(cms)/cms/login/_features/login/actions.ts` | Server Actions — signIn, signOut |
-| `src/app/(cms)/cms/register/page.tsx` | Server Component |
-| `src/app/(cms)/cms/register/_features/register/schema.ts` | Zod schema registro |
-| `src/app/(cms)/cms/register/_features/register/view.tsx` | Client Component — formulário RHF |
-| `src/app/(cms)/cms/register/_features/register/actions.ts` | Server Actions — signUp |
-| `src/app/(cms)/cms/dashboard/page.tsx` | Dashboard — Server Component |
-| `src/app/(cms)/cms/dashboard/_features/dashboard/view.tsx` | Conteúdo do dashboard |
-| `src/components/cms/CMSShell.tsx` | Shell com Sidebar + conteúdo |
-| `src/components/cms/Sidebar/index.tsx` | Server Component — container da sidebar |
-| `src/components/cms/Sidebar/SidebarNav.tsx` | Client Component — links com usePathname |
-| `src/components/cms/Sidebar/SidebarUserMenu.tsx` | Client Component — avatar + logout |
-| `src/components/cms/TopBar/index.tsx` | Client Component — topbar do CMS |
-| `docs/tech/adr/008-supabase-ssr-auth.md` | ADR-008 |
-| `docs/tech/adr/009-cms-route-group.md` | ADR-009 |
-| `docs/tech/adr/010-proxy-route-protection.md` | ADR-010 |
-| `docs/tech/adr/011-rhf-zod-cms-forms.md` | ADR-011 |
+| `src/app/(cms)/cms/dashboard/admins/novo/page.tsx` | Server Component — ponto de entrada |
+| `src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/schema.ts` | Zod schema |
+| `src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/viewModel.tsx` | Lógica + form |
+| `src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/view.tsx` | UI pura |
+| `src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/actions.ts` | Server Action |
+| `src/lib/supabase/admin.ts` | `createAdminClient()` com service role key |
 
-### Modificar (existentes)
+### Não modificar
 
 | Arquivo | Motivo |
 |---|---|
-| `package.json` | Adicionar `@supabase/supabase-js`, `@supabase/ssr`, `zod`, `react-hook-form`, `@hookform/resolvers` |
-| `.env.local` | Adicionar variáveis Supabase |
-| `docs/tech/architecture.md` | Adicionar seção do fluxo CMS ao diagrama geral |
-
----
-
-## Diagrama de Fluxo de Auth
-
-```
-Browser → GET /cms/dashboard
-    ↓
-middleware.ts (Proxy)
-  └─ lê cookie sb-* do Supabase
-  └─ sem sessão → redirect /cms/login
-  └─ com sessão → next()
-    ↓
-(cms)/layout.tsx (Server Component)
-  └─ createServerClient → supabase.auth.getUser()
-  └─ sem user → redirect /cms/login
-  └─ com user → busca profile em public.profiles
-  └─ renderiza CMSShell com user + profile
-    ↓
-(cms)/cms/dashboard/page.tsx
-  └─ Server Component puro — sem lógica de auth
-```
-
-```
-Browser → POST /cms/login (via Server Action)
-    ↓
-actions.ts
-  └─ valida schema Zod server-side
-  └─ supabase.auth.signInWithPassword()
-  └─ erro → retorna { errors } para useActionState
-  └─ sucesso → redirect /cms/dashboard
-```
+| `src/app/(cms)/cms/register/*` | Auto-cadastro existente — fora do escopo |
+| `src/app/(cms)/cms/dashboard/layout.tsx` | Proteção já existente |
+| `src/proxy.ts` ou `src/middleware.ts` | Já cobre `/cms/dashboard/*` |
+| Tabela `admin_profiles` | Estrutura existente é suficiente |

--- a/docs/.squads/sessions/portal-nexora/architecture.md.bak
+++ b/docs/.squads/sessions/portal-nexora/architecture.md.bak
@@ -1,187 +1,442 @@
-# Decisão Arquitetural: Migração HTML → Next.js App Router
+# CMS — Arquitetura do Fluxo de Autenticação e Painel Administrativo
 
-**Data:** 2026-04-25
-**Agent:** Ana Arquitetura
-
----
-
-## Entendimento da Task
-
-Converter as páginas estáticas legadas (`index.html` e `eventos.html` + `assets/css/estilo.css` + `assets/js/script.js`) para o stack atual do Portal Nexora: Next.js 16 App Router, React 19, Tailwind CSS v4 e Shadcn/UI. As páginas são majoritariamente estáticas (sem formulários, sem server state), com exceção do menu hambúrguer responsivo que requer interatividade client-side.
+> Produzido por Ana Arquitetura (ana-arquitetura-fe) — Squad frontend-001  
+> Data: 2026-04-30 | Status: Aprovado para implementação
 
 ---
 
-## Mapeamento de Rotas
+## 1. Entendimento da Task
 
-| Arquivo legado | Rota Next.js |
-|---|---|
-| `index.html` | `src/app/page.tsx` |
-| `eventos.html` | `src/app/eventos/page.tsx` |
+O objetivo é criar o fluxo completo de acesso ao CMS do Portal Nexora: autenticação via Supabase Auth (login/logout/cadastro), proteção de rotas, sidebar/navbar do painel e schema do banco para múltiplos perfis de acesso (admin, content_creator, professor). O CMS roda sob o route group `(cms)` e deve ser completamente isolado do site público.
 
 ---
 
-## Estrutura de Componentes
+## 2. Estrutura de Arquivos e Pastas
 
 ```
 src/
 ├── app/
-│   ├── layout.tsx                  ← já existe — adicionar Header e Footer
-│   ├── page.tsx                    ← Server Component — home page
-│   └── eventos/
-│       └── page.tsx                ← Server Component — eventos
+│   ├── (publics)/                         # site público (existente)
+│   ├── (cms)/                             # route group CMS — não gera segmento de URL
+│   │   ├── layout.tsx                     # CMS layout — valida sessão, renderiza Sidebar
+│   │   ├── login/
+│   │   │   ├── page.tsx                   # Server Component — sem lógica, sem hooks
+│   │   │   └── _features/login/
+│   │   │       ├── schema.ts              # Zod schema do formulário de login
+│   │   │       ├── view.tsx               # Client Component — formulário RHF
+│   │   │       └── actions.ts             # Server Actions — signIn, signOut
+│   │   ├── register/
+│   │   │   ├── page.tsx
+│   │   │   └── _features/register/
+│   │   │       ├── schema.ts
+│   │   │       ├── view.tsx
+│   │   │       └── actions.ts
+│   │   └── dashboard/
+│   │       ├── page.tsx                   # Dashboard principal (Server Component)
+│   │       └── _features/dashboard/
+│   │           └── view.tsx               # Conteúdo do dashboard
+│   ├── globals.css
+│   ├── favicon.ico
+│   └── layout.tsx                         # Root layout (existente)
 │
 ├── components/
-│   └── layout/
-│       ├── Header/
-│       │   ├── Header.tsx          ← Client Component (menu toggle)
-│       │   └── index.ts
-│       └── Footer/
-│           ├── Footer.tsx          ← Server Component
-│           └── index.ts
+│   ├── cms/                               # Componentes exclusivos do CMS
+│   │   ├── Sidebar/
+│   │   │   ├── index.tsx                  # Server Component — lê sessão e renderiza
+│   │   │   ├── SidebarNav.tsx             # Client Component — links ativos com usePathname
+│   │   │   └── SidebarUserMenu.tsx        # Client Component — avatar + logout
+│   │   ├── TopBar/
+│   │   │   └── index.tsx                  # Client Component — título da página + ações
+│   │   └── CMSShell.tsx                   # Layout shell: Sidebar + área de conteúdo
+│   ├── layout/                            # Header/Footer públicos (existente)
+│   └── ui/                               # Shadcn (existente)
 │
-└── _features/
-    ├── home/
-    │   ├── view.tsx                ← Client Component (se precisar de interatividade futura)
-    │   ├── HeroSection.tsx         ← Server Component
-    │   ├── CursosDestaque.tsx      ← Server Component
-    │   ├── ProjetosSociais.tsx     ← Server Component
-    │   ├── ImpactoSection.tsx      ← Server Component
-    │   └── ParceirosCTA.tsx        ← Server Component
-    └── eventos/
-        ├── HeroEventos.tsx         ← Server Component
-        ├── ProximosEventos.tsx     ← Server Component
-        └── EventosGravados.tsx     ← Server Component
+├── lib/
+│   ├── utils.ts                           # cn() (existente)
+│   └── supabase/
+│       ├── client.ts                      # createBrowserClient — uso em Client Components
+│       ├── server.ts                      # createServerClient — uso em Server Components e Actions
+│       └── middleware.ts                  # createServerClient para uso no proxy
+│
+└── middleware.ts                          # Proxy Next.js — proteção de rotas CMS
+```
+
+> **Nota de rota:** O route group `(cms)` isola o CMS sem prefixar URLs. As rotas resultantes são `/login`, `/register` e `/dashboard`. Se houver conflito com rotas públicas que usem os mesmos slugs, o route group deverá ser renomeado para `(cms-area)` e as rotas prefixadas: `/cms/login`, `/cms/dashboard`.
+>
+> **Decisão adotada aqui:** Usar prefixo `/cms/*` via route group `(cms)` + pasta `cms/` dentro de `(cms)`. Rotas resultantes: `/cms/login`, `/cms/register`, `/cms/dashboard`.  
+> Estrutura revisada:
+
+```
+src/app/
+└── (cms)/
+    └── cms/                               # gera o prefixo /cms na URL
+        ├── login/page.tsx                 → /cms/login
+        ├── register/page.tsx              → /cms/register
+        └── dashboard/page.tsx             → /cms/dashboard
 ```
 
 ---
 
-## Decisões de Estado
+## 3. Decisões de Estado
 
-| Estado | Tipo | Justificativa |
-|--------|------|---------------|
-| Menu mobile (aberto/fechado) | `useState` local no `Header` | UI local, sem compartilhamento, sem persistência |
-| Conteúdo de cursos | Static — hardcoded no componente | Não há API ainda; dados mudam raramente |
-| Conteúdo de eventos | Static — hardcoded no componente | Igual — futuramente virá de Supabase |
-
-> [RESPEITADA] **ADR-001:** `page.tsx` é Server Component em ambas as rotas — lógica de interatividade (menu toggle) foi isolada no `Header.tsx` como Client Component.
+| Contexto | Decisão | Justificativa |
+|---|---|---|
+| Dados da sessão autenticada | Lidos via `createServerClient` no Server Component/layout | Sem estado global no cliente — evita prop drilling e hydration mismatch |
+| Formulários de login/cadastro | `useActionState` + Server Actions | Padrão Next.js 16 App Router; sem fetch manual; sem `useState` para campos |
+| Rota ativa na Sidebar | `usePathname()` no `SidebarNav` (Client Component) | API de navegação só disponível no cliente |
+| Logout | Server Action com `supabase.auth.signOut()` + `redirect()` | Garante limpeza de cookies pelo servidor |
+| Dados do usuário logado para Sidebar | Passados como props do Server Component pai | Evita criar Context desnecessário; o volume de dados é mínimo (nome, role, avatar) |
 
 ---
 
-## Contratos dos Componentes Principais
+## 4. Contratos dos Componentes Principais
 
 ```typescript
-// Header.tsx — Client Component
-// Sem props externas; autocontido
+// src/lib/supabase/types.ts
 
-// HeroSection.tsx
-type HeroSectionProps = {
-  title: string
-  subtitle: string
-  primaryCta: { label: string; href: string }
-  secondaryCta: { label: string; href: string }
-}
+type AdminRole = 'admin' | 'content_creator' | 'professor'
 
-// CursosDestaque.tsx
-type Curso = {
+type AdminProfile = {
   id: string
-  title: string
-  description: string
-  href: string
+  user_id: string
+  full_name: string
+  role: AdminRole
+  avatar_url: string | null
+  created_at: string
 }
 
-type CursosDestaqueProps = {
-  cursos: Curso[]
-}
-
-// ProjetosSociais.tsx
-type Projeto = {
+type SessionUser = {
   id: string
-  title: string
-  description: string
+  email: string
+  profile: AdminProfile
+}
+```
+
+```typescript
+// src/components/cms/Sidebar/index.tsx
+type SidebarProps = {
+  user: SessionUser
 }
 
-type ProjetosSociaisProps = {
-  projetos: Projeto[]
-}
-
-// ImpactoSection.tsx
-type ImpactoItem = {
-  id: string
-  value: string
+// src/components/cms/Sidebar/SidebarNav.tsx
+type NavItem = {
   label: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
 }
 
-type ImpactoSectionProps = {
-  items: ImpactoItem[]
+type SidebarNavProps = {
+  items: NavItem[]
 }
 
-// EventoCard.tsx (compartilhado entre ProximosEventos e EventosGravados)
-type EventoCard = {
-  id: string
-  title: string
-  description: string
-  imageUrl: string
-  imageAlt: string
-  youtubeUrl: string
-  date?: string
-  time?: string
+// src/components/cms/Sidebar/SidebarUserMenu.tsx
+type SidebarUserMenuProps = {
+  user: SessionUser
 }
+
+// src/components/cms/CMSShell.tsx
+type CMSShellProps = {
+  user: SessionUser
+  children: React.ReactNode
+}
+```
+
+```typescript
+// src/app/(cms)/cms/login/_features/login/schema.ts
+import { z } from 'zod'
+
+export const loginSchema = z.object({
+  email: z.email({ error: 'Email inválido' }),
+  password: z.string().min(8, { error: 'Mínimo 8 caracteres' }),
+})
+
+export type LoginFormData = z.infer<typeof loginSchema>
+```
+
+```typescript
+// src/app/(cms)/cms/register/_features/register/schema.ts
+import { z } from 'zod'
+
+export const registerSchema = z.object({
+  full_name: z.string().min(2, { error: 'Nome obrigatório' }),
+  email: z.email({ error: 'Email inválido' }),
+  password: z.string().min(8, { error: 'Mínimo 8 caracteres' }),
+  role: z.enum(['admin', 'content_creator', 'professor']),
+})
+
+export type RegisterFormData = z.infer<typeof registerSchema>
+```
+
+```typescript
+// Tipo do estado de Server Actions (useActionState)
+type ActionState = {
+  errors?: Record<string, string[]>
+  message?: string
+} | undefined
 ```
 
 ---
 
-## ADRs Aplicadas
+## 5. Schema Supabase
 
-### ADR-FE-001: Separação Client/Server no Layout
+### SQL — tabela `profiles`
 
-**Contexto:** O Header precisa de `useState` para o menu mobile, mas `layout.tsx` é Server Component.
+```sql
+-- Executar no SQL Editor do Supabase
+-- Depende da tabela auth.users gerenciada pelo Supabase Auth
 
-**Decisão:** Criar `Header.tsx` como Client Component separado e importá-lo no `layout.tsx`. O layout permanece Server Component.
+create type public.admin_role as enum (
+  'admin',
+  'content_creator',
+  'professor'
+);
 
-**Alternativas rejeitadas:**
-- Tornar `layout.tsx` client component: rejeitado — perde os benefícios de SSR e viola ADR-001
-- Usar URL search params para controlar menu: rejeitado — causa re-render da página inteira, má UX
+create table public.profiles (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  full_name   text not null,
+  role        public.admin_role not null default 'content_creator',
+  avatar_url  text,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
 
-**Consequências:**
-✅ `layout.tsx` permanece Server Component
-✅ Interatividade do menu isolada num componente pequeno e testável
-⚠ Hidratação necessária apenas para o Header, não para o restante da página
+  constraint profiles_user_id_unique unique (user_id)
+);
+
+-- RLS obrigatório
+alter table public.profiles enable row level security;
+
+-- Admins veem todos os profiles
+create policy "admins_read_all_profiles"
+  on public.profiles for select
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.user_id = auth.uid()
+        and p.role = 'admin'
+    )
+  );
+
+-- Usuário lê seu próprio profile
+create policy "user_read_own_profile"
+  on public.profiles for select
+  using (user_id = auth.uid());
+
+-- Apenas admins criam profiles de outros usuários via service role
+-- Inserção via service role no Server Action de registro (sem RLS bypass no cliente)
+
+-- Trigger para atualizar updated_at
+create or replace function public.update_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger profiles_updated_at
+  before update on public.profiles
+  for each row execute function public.update_updated_at();
+```
+
+### Variáveis de Ambiente necessárias
+
+```bash
+# .env.local
+NEXT_PUBLIC_SUPABASE_URL=https://xxxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...          # cliente browser
+SUPABASE_SERVICE_ROLE_KEY=eyJ...              # NUNCA expor ao cliente
+```
 
 ---
 
-## Arquivos a Modificar/Criar
+## 6. ADRs
 
-- `src/app/layout.tsx` — adicionar `<Header />` e `<Footer />`
-- `src/app/page.tsx` — home page (criar ou substituir)
-- `src/app/eventos/page.tsx` — página de eventos (criar)
-- `src/components/layout/Header/Header.tsx` — criar
-- `src/components/layout/Header/index.ts` — criar
-- `src/components/layout/Footer/Footer.tsx` — criar
-- `src/components/layout/Footer/index.ts` — criar
-- `src/_features/home/HeroSection.tsx` — criar
-- `src/_features/home/CursosDestaque.tsx` — criar
-- `src/_features/home/ProjetosSociais.tsx` — criar
-- `src/_features/home/ImpactoSection.tsx` — criar
-- `src/_features/home/ParceirosCTA.tsx` — criar
-- `src/_features/eventos/HeroEventos.tsx` — criar
-- `src/_features/eventos/ProximosEventos.tsx` — criar
-- `src/_features/eventos/EventosGravados.tsx` — criar
-- `public/imagens/` — mover imagens de `imagens/` para cá
+### ADR-008 — Estratégia de Auth: Supabase SSR via `@supabase/ssr`
+
+**Data:** 2026-04-30 | **Status:** Aceita
+
+**Contexto:** O Supabase Auth pode ser usado de três formas: (a) client-only com `@supabase/supabase-js` + `localStorage`; (b) `@supabase/auth-helpers-nextjs` (depreciado); (c) `@supabase/ssr` com cookies.
+
+**Decisão:** Usar `@supabase/ssr` com dois clients distintos:
+- `createBrowserClient` → Client Components (leitura de sessão no cliente)
+- `createServerClient` → Server Components, Server Actions e Proxy (leitura e escrita de cookies)
+
+**Trade-offs:**
+- ✅ Sessão disponível no servidor antes do render — sem flicker de autenticação
+- ✅ Cookies HttpOnly gerenciados pelo Supabase — sem exposição de tokens no `localStorage`
+- ✅ Compatível com Next.js App Router e Proxy (Node.js runtime)
+- ❌ Requer dois clients distintos — mais boilerplate
+- ❌ `@supabase/ssr` é o pacote correto; `@supabase/auth-helpers-nextjs` está depreciado e NÃO deve ser usado
+
+**Dependências a instalar:**
+```bash
+npm install @supabase/supabase-js @supabase/ssr
+```
 
 ---
 
-## Pontos de Atenção para o Dev
+### ADR-009 — Estrutura do Route Group CMS
 
-1. **Imagens:** Os HTMLs referenciam `imagens/Loo_whiteBgColor.png`, `imagens/live_segurança.jpeg`, `imagens/PALESTRA*.jpg/jpeg/png`. Mover para `public/imagens/` — Next.js serve arquivos estáticos de `public/`. Usar `<Image>` do Next.js para otimização automática.
+**Data:** 2026-04-30 | **Status:** Aceita
 
-2. **Links entre páginas:** `href="eventos.html"` → `href="/eventos"`, `href="index.html"` → `href="/"`.
+**Contexto:** O CMS precisa de layout próprio (com Sidebar) sem contaminar o layout do site público.
 
-3. **Menu mobile:** O `script.js` toggle provavelmente usa `classList.toggle`. Substituir por `useState(false)` no `Header.tsx`.
+**Decisão:** Route group `(cms)` com pasta `cms/` interna, gerando rotas `/cms/*`. O layout `(cms)/layout.tsx` envolve apenas as rotas do CMS.
 
-4. **cn() obrigatório:** Todo `className` JSX deve usar `cn()` de `@/lib/utils` — ADR-007.
+**Trade-offs:**
+- ✅ Isolamento total de layout entre site público e CMS
+- ✅ Prefixo `/cms` semânticamente claro nas URLs
+- ✅ `page.tsx` dentro de `(cms)/cms/login/` → rota `/cms/login` sem segmento extra do route group
+- ❌ Nesting duplo `(cms)/cms/` é contra-intuitivo — documentar para o time
 
-5. **Sem interface:** Todos os tipos usam `type`, nunca `interface` — ADR-005.
+**Alternativa rejeitada:** Route group `(cms)` diretamente com `login/page.tsx` → rota `/login` colide com possível página de login futuro do site público.
 
-6. **Tailwind v4:** Não criar `tailwind.config.js`. Customizações vão em `globals.css` via `@theme` — ADR-003.
+---
 
-7. **Logo:** A home usa `<img src="imagens/Loo_whiteBgColor.png">` e eventos usa texto "Nexora" como logo. Padronizar: usar a imagem em ambas.
+### ADR-010 — Proteção de Rotas: Proxy (middleware.ts) como camada primária
+
+**Data:** 2026-04-30 | **Status:** Aceita
+
+**Contexto:** Duas opções para proteger `/cms/*`:  
+(a) Verificar sessão no `layout.tsx` do CMS  
+(b) Usar o Proxy (`middleware.ts`) para redirecionar antes do render
+
+**Decisão:** Proxy (`src/middleware.ts`) como camada primária + verificação no layout como camada secundária.
+
+O Proxy faz verificação otimista lendo o cookie de sessão do Supabase (sem query ao banco). O layout faz verificação definitiva chamando `supabase.auth.getUser()`.
+
+```
+Request → Proxy (cookie check) → Layout (getUser()) → Page
+```
+
+**Trade-offs:**
+- ✅ Proxy evita render de páginas protegidas para usuários não autenticados
+- ✅ Layout como segunda linha de defesa — não depende apenas do cookie
+- ✅ Proxy não bloqueia rotas públicas (`/`, `/eventos`, etc.)
+- ❌ Lógica de auth em dois lugares — manter sincronizado
+- ❌ Proxy roda em todo request — manter lógica mínima (só leitura de cookie, sem DB)
+
+**Alternativa rejeitada:** Layout-only check — renderiza a página no servidor antes de redirecionar, causando flash e potencial leak de dados.
+
+---
+
+### ADR-011 — Formulários CMS: React Hook Form + Zod + useActionState
+
+**Data:** 2026-04-30 | **Status:** Aceita
+
+**Contexto:** Formulários de login e cadastro precisam de validação client-side e server-side. Zod e RHF não estão instalados no projeto.
+
+**Decisão:** Instalar Zod e React Hook Form. Usar o padrão:
+- Schema Zod em `schema.ts` — fonte única de validação
+- RHF com `resolver` Zod para validação client-side em tempo real
+- `useActionState` para receber erros do Server Action
+- Server Action valida com o mesmo schema Zod antes de chamar Supabase
+
+**Dependências a instalar:**
+```bash
+npm install zod react-hook-form @hookform/resolvers
+```
+
+**Trade-offs:**
+- ✅ Validação consistente client e server com o mesmo schema
+- ✅ Sem `useState` para campos — conforme regra crítica do projeto
+- ✅ `type LoginFormData = z.infer<typeof loginSchema>` — sem duplicação de tipos
+- ❌ Mais dependências no projeto
+- ❌ RHF é Client Component — `view.tsx` precisa de `"use client"`
+
+---
+
+## 7. Pontos de Atenção para o Dev
+
+1. **`@supabase/auth-helpers-nextjs` está depreciado** — usar exclusivamente `@supabase/ssr`. Qualquer exemplo da internet que use `createClientComponentClient` ou `createServerComponentClient` está desatualizado.
+
+2. **Proxy vs Middleware nomenclatura:** No Next.js 16, o arquivo é `middleware.ts` mas a doc interna chama de "Proxy". O arquivo fica na raiz do projeto (`src/middleware.ts`), não dentro de `app/`.
+
+3. **`cookies()` é assíncrono no Next.js 16** — sempre `await cookies()`, não `cookies()` síncrono.
+
+4. **`createServerClient` precisa de handler de cookies** — o server client do `@supabase/ssr` requer que você passe `get`/`set`/`remove` de cookies manualmente. Os três contextos (Server Component, Server Action, Proxy) têm implementações ligeiramente diferentes porque o objeto `cookies()` do Next.js se comporta diferente em cada contexto.
+
+5. **Inserção de profile após cadastro** — após `supabase.auth.signUp()`, inserir o registro em `public.profiles` usando o `service role client` (server-side) para contornar a RLS de inserção.
+
+6. **Login split-layout desktop-first** — o `view.tsx` do login usa grid `lg:grid-cols-2`. Em mobile, apenas o formulário é exibido; o painel com a logo é oculto com `hidden lg:flex`.
+
+7. **`SidebarNav` e `usePathname`** — `usePathname` só funciona em Client Components. O `SidebarNav` deve ter `"use client"` no topo. O `Sidebar/index.tsx` pai permanece Server Component e passa os itens como prop.
+
+8. **Zod v4 breaking change** — A versão atual do Zod usa `z.string().min(n, { error: '...' })` em vez de `{ message: '...' }`. Confirmar a versão instalada antes de escrever schemas.
+
+9. **`page.tsx` nunca recebe props de sessão** — a sessão é lida no `layout.tsx` (Server Component) e passada via props para o `CMSShell`, que repassa para `Sidebar` e `TopBar`. `page.tsx` permanece sem nenhuma lógica de auth.
+
+---
+
+## 8. Arquivos a Modificar/Criar
+
+### Criar (novos)
+
+| Arquivo | Descrição |
+|---|---|
+| `src/middleware.ts` | Proxy — proteção de rotas `/cms/*` |
+| `src/lib/supabase/client.ts` | `createBrowserClient` |
+| `src/lib/supabase/server.ts` | `createServerClient` para Server Components/Actions |
+| `src/lib/supabase/middleware.ts` | `createServerClient` para uso no Proxy |
+| `src/lib/supabase/types.ts` | `AdminRole`, `AdminProfile`, `SessionUser` |
+| `src/app/(cms)/layout.tsx` | Layout CMS — verifica sessão, renderiza CMSShell |
+| `src/app/(cms)/cms/login/page.tsx` | Server Component — sem lógica |
+| `src/app/(cms)/cms/login/_features/login/schema.ts` | Zod schema login |
+| `src/app/(cms)/cms/login/_features/login/view.tsx` | Client Component — formulário RHF |
+| `src/app/(cms)/cms/login/_features/login/actions.ts` | Server Actions — signIn, signOut |
+| `src/app/(cms)/cms/register/page.tsx` | Server Component |
+| `src/app/(cms)/cms/register/_features/register/schema.ts` | Zod schema registro |
+| `src/app/(cms)/cms/register/_features/register/view.tsx` | Client Component — formulário RHF |
+| `src/app/(cms)/cms/register/_features/register/actions.ts` | Server Actions — signUp |
+| `src/app/(cms)/cms/dashboard/page.tsx` | Dashboard — Server Component |
+| `src/app/(cms)/cms/dashboard/_features/dashboard/view.tsx` | Conteúdo do dashboard |
+| `src/components/cms/CMSShell.tsx` | Shell com Sidebar + conteúdo |
+| `src/components/cms/Sidebar/index.tsx` | Server Component — container da sidebar |
+| `src/components/cms/Sidebar/SidebarNav.tsx` | Client Component — links com usePathname |
+| `src/components/cms/Sidebar/SidebarUserMenu.tsx` | Client Component — avatar + logout |
+| `src/components/cms/TopBar/index.tsx` | Client Component — topbar do CMS |
+| `docs/tech/adr/008-supabase-ssr-auth.md` | ADR-008 |
+| `docs/tech/adr/009-cms-route-group.md` | ADR-009 |
+| `docs/tech/adr/010-proxy-route-protection.md` | ADR-010 |
+| `docs/tech/adr/011-rhf-zod-cms-forms.md` | ADR-011 |
+
+### Modificar (existentes)
+
+| Arquivo | Motivo |
+|---|---|
+| `package.json` | Adicionar `@supabase/supabase-js`, `@supabase/ssr`, `zod`, `react-hook-form`, `@hookform/resolvers` |
+| `.env.local` | Adicionar variáveis Supabase |
+| `docs/tech/architecture.md` | Adicionar seção do fluxo CMS ao diagrama geral |
+
+---
+
+## Diagrama de Fluxo de Auth
+
+```
+Browser → GET /cms/dashboard
+    ↓
+middleware.ts (Proxy)
+  └─ lê cookie sb-* do Supabase
+  └─ sem sessão → redirect /cms/login
+  └─ com sessão → next()
+    ↓
+(cms)/layout.tsx (Server Component)
+  └─ createServerClient → supabase.auth.getUser()
+  └─ sem user → redirect /cms/login
+  └─ com user → busca profile em public.profiles
+  └─ renderiza CMSShell com user + profile
+    ↓
+(cms)/cms/dashboard/page.tsx
+  └─ Server Component puro — sem lógica de auth
+```
+
+```
+Browser → POST /cms/login (via Server Action)
+    ↓
+actions.ts
+  └─ valida schema Zod server-side
+  └─ supabase.auth.signInWithPassword()
+  └─ erro → retorna { errors } para useActionState
+  └─ sucesso → redirect /cms/dashboard
+```

--- a/docs/.squads/sessions/portal-nexora/context.md
+++ b/docs/.squads/sessions/portal-nexora/context.md
@@ -17,6 +17,16 @@ O projeto iniciou com protótipos HTML estáticos. A migração garante que todo
 
 ---
 
+## Sessão 2026-04-30 — CMS: Cadastro de Administradores
+
+### O que é
+Formulário de cadastro de novos administradores no CMS do Portal Nexora, seguindo os ADRs do projeto (MVVM em `_features/`, RHF + Zod, type-only, cn()).
+
+### Por que existe
+O CMS já possui login e dashboard para admins existentes, mas não há fluxo para criar novos administradores a partir da interface. O cadastro deve integrar com Supabase Auth e inserir o profile na tabela `admin_profiles` com o role adequado.
+
+---
+
 ## Sessão 2026-04-30 — CMS Admin
 
 ### O que é

--- a/docs/.squads/sessions/portal-nexora/feature-notes.md
+++ b/docs/.squads/sessions/portal-nexora/feature-notes.md
@@ -1,48 +1,37 @@
-# Feature Notes: Migração HTML → Next.js App Router
+# Feature Notes: CMS — Criar Novos Administradores
 
-**Data:** 2026-04-25
+**Data:** 2026-04-30
 **Squad:** frontend-001
-
----
 
 ## O que foi implementado
 
-- **2 rotas Next.js App Router**: `src/app/page.tsx` (home) e `src/app/eventos/page.tsx` substituem `index.html` e `eventos.html`
-- **Layout compartilhado** (`src/app/layout.tsx`) atualizado com `<Header>` e `<Footer>` globais, metadata em pt-BR
-- **Header responsivo** (`src/components/layout/Header/`) como Client Component com menu hambúrguer via `useState` — único ponto de interatividade client-side
-- **10 componentes de feature** em `src/_features/home/` e `src/_features/eventos/` mapeando cada seção das páginas legadas; todos Server Components exceto o Header
-- **Imagens migradas** de `imagens/` para `public/images/` e servidas via `<Image>` do Next.js com `alt` descritivo em todas
-
----
+- `src/lib/supabase/admin.ts` — `createAdminClient()` com service role key (sem cookie handling), separado do client padrão
+- `src/app/(cms)/cms/dashboard/admins/novo/page.tsx` — Server Component puro com metadata, sem lógica
+- `_features/NovoAdmin/schema.ts` — Zod schema com refinamento de confirmação de senha e enum de roles
+- `_features/NovoAdmin/viewModel.tsx` — `useActionState` + `useForm` + `useRouter` encapsulados, sem JSX
+- `_features/NovoAdmin/view.tsx` — UI pura com Shadcn + `<select>` nativo estilizado; zero lógica
+- `_features/NovoAdmin/actions.ts` — Server Action usando `auth.admin.createUser` + rollback via `deleteUser` se o profile falhar
 
 ## Decisões técnicas tomadas
 
-- **Dados hardcoded nas páginas por ora**: `cursos`, `projetos`, `impacto` e `eventos` declarados como constantes em `page.tsx` e `eventos/page.tsx`. Decisão consciente — sem API Supabase ainda. Quando vier o backend, extrair para `data.ts` ou server actions.
-- **`_features/` sem `view.tsx`/`viewModel.tsx`**: as páginas são estáticas sem formulários ou lógica de negócio, então o padrão MVVM completo (ADR-004) foi simplificado para componentes diretos. Qualquer página que ganhar formulário ou estado complexo deve migrar para MVVM completo.
-- **Sem `tailwind.config.js`**: cores da marca (`blue-900`, `emerald-500`, `gray-100`) usam classes utilitárias padrão do Tailwind v4 que correspondem visualmente ao CSS legado (`#1e3a8a`, `#10b981`, `#f3f4f6`). Se a paleta mudar, criar variáveis em `globals.css` via `@theme`.
-
----
+- **`<select>` nativo** em vez de Shadcn Select (não instalado). Estilizado com classes Tailwind compatíveis com a altura/border do `<Input>`.
+- **`flatten((issue) => issue.message)`** — Zod v4 deprecou a assinatura zero-argumento de `.flatten()`. A forma correta em v4 é passar um mapper.
+- **Rollback explícito**: se a inserção em `admin_profiles` falhar após `createUser`, o auth user é deletado imediatamente. Mantém consistência sem depender de triggers ou jobs externos.
+- **`router.back()` no cancelar**: decisão deliberada — o comportamento padrão é voltar na história do browser. Se acessado diretamente, navega para fora do CMS (comportamento aceitável; listagem de admins está fora do escopo desta task).
 
 ## Pontos de atenção para manutenção futura
 
-1. **`/login` ainda não existe**: o botão "Entrar" no Header aponta para `/login` — retorna 404. Criar a rota ou mudar para `href="#"` enquanto não implementada.
-2. **`live_segurança.jpeg`**: nome do arquivo com `ç` pode causar problemas em deploys Linux/Vercel. Renomear para `live_seguranca.jpeg` e atualizar o `imageUrl` em `eventos/page.tsx`.
-3. **Dados estáticos**: conteúdo de cursos, projetos e eventos está hardcoded. Quando o Supabase for integrado, mover para Server Actions ou `generateStaticParams`.
-4. **`_features/` não é roteado**: a pasta `_features/` usa `_` para ficar invisível ao App Router do Next.js. Manter esse padrão.
-
----
+1. **`SUPABASE_SERVICE_ROLE_KEY`** deve existir em `.env.local` (e nas variáveis de ambiente do Vercel). A ausência faz `createAdminClient()` criar um client com chave `undefined`, e `auth.admin.*` retorna 401 silenciosamente.
+2. **`auth.admin.createUser`** requer que o projeto Supabase tenha Auth habilitado e que a service role key tenha permissão de admin. Verificar no dashboard Supabase se a key é a correta.
+3. **Rota `/cms/dashboard/admins/novo`** está protegida pelo `proxy.ts` herdado do `(cms)/layout.tsx`. Não precisa de proteção adicional na page.tsx.
+4. **`select` nativo no dark mode** pode exibir fundo branco em alguns browsers. Se o projeto implementar dark mode, considerar trocar por Shadcn Select ou uma lib de select acessível.
+5. **Mensagem de erro do Supabase** (`authError?.message`) pode vir em inglês. Mapear para pt-BR antes de expor ao usuário é uma melhoria futura pendente.
 
 ## BLOCKERs resolvidos do review
 
-- **[BLOCKER] URL duplicada em `eventos/page.tsx`**: "Desenvolvendo com Segurança" apontava para o mesmo `youtubeUrl` do evento seguinte (`IZyad7yAiOk`). Corrigido para `watch?v=Wwet0QK8yJU` conforme o link da imagem original no HTML legado.
-
----
+- **[BLOCKER] Usuário auth órfão**: corrigido adicionando `await adminClient.auth.admin.deleteUser(authData.user.id)` antes do `return` de erro no profile. O banco retorna a um estado consistente em caso de falha parcial.
 
 ## SUGGESTIONs pendentes (débito técnico)
 
-| Sugestão | Prioridade | Motivo de adiar |
-|---|---|---|
-| Refatorar padrão de visibilidade do `<nav>` no Header | Baixa | Funciona corretamente; melhoria de legibilidade apenas |
-| Mover dados hardcoded para `data.ts` em `_features/` | Média | Aguardando integração com Supabase para definir estrutura final |
-| Renomear `live_segurança.jpeg` para remover `ç` | Média | Não bloqueia localmente; risco no deploy Vercel |
-| Criar rota `/login` ou ajustar href do Header | Alta | Depende de decisão de produto sobre o fluxo de auth |
+- **`select` nativo / bg-transparent**: cosmético, a tratar quando dark mode for implementado
+- **Mensagem de erro do Supabase em inglês**: mapear `authError?.message` para pt-BR na próxima iteração do CMS

--- a/docs/.squads/sessions/portal-nexora/memories.md
+++ b/docs/.squads/sessions/portal-nexora/memories.md
@@ -11,6 +11,18 @@
 <!-- /SUMMARY -->
 
 <!-- RECENTES -->
+## [frontend-001 · ana-arquitetura-fe] — 2026-04-30
+
+[DECISÃO CRÍTICA] Padrões aprovados — CMS Criar Admin:
+- `createAdminClient()` em `src/lib/supabase/admin.ts` (service role, sem cookies) — separado de `createClient()`
+- `auth.admin.createUser` + rollback `deleteUser` se profile falhar — padrão de consistência para criações em dois passos
+- `flatten((issue) => issue.message)` é o padrão Zod v4 (sem args está depreciado)
+- `viewModel.tsx` separado de `view.tsx` é o padrão correto (ADR-004) — features CMS antigas não seguem, esta é a referência
+
+## Sessão 2026-04-30 (run 3)
+Task: CMS — Formulário de cadastro de novos administradores seguindo ADRs
+Issue: —
+
 ## Sessão 2026-04-30 (run 2)
 Task: CMS — Segurança, domínios e proteção
 Decisões documentadas em docs/tech/security/cms-domain-architecture.md

--- a/docs/.squads/sessions/portal-nexora/review-notes.md
+++ b/docs/.squads/sessions/portal-nexora/review-notes.md
@@ -143,3 +143,79 @@ O Footer agora tem descrição da marca, links de navegação e copyright — al
 **Aprovado. Zero BLOCKERs.**
 
 O redesign Shadcn está bem executado. A SUGGESTION de documentar o padrão `render` não bloqueia nada.
+
+---
+
+# Review Notes — CMS: Criar Novos Administradores
+
+**Data:** 2026-04-30
+**Reviewer:** Renata Revisão
+
+## Resumo
+- BLOCKERs: 1
+- SUGGESTIONs: 2
+- QUESTIONs: 1
+- PRASEs: 3
+
+## Comentários
+
+---
+
+[BLOCKER] `actions.ts` — usuário auth órfão se inserção de profile falhar
+
+Por que é um problema: `auth.admin.createUser()` é chamado primeiro e tem sucesso. Se o `.insert()` em `admin_profiles` falhar em seguida (constraint, timeout, permissão), o usuário existe em `auth.users` mas sem profile. Na próxima tentativa de login, `dashboard/layout.tsx` recebe `profile: null` — o usuário entra no sistema sem role. Além disso, a mesma conta não pode ser criada novamente pois o e-mail já existe no Auth.
+
+Fix sugerido:
+```typescript
+if (profileError) {
+  // limpar o usuário auth para manter consistência
+  await adminClient.auth.admin.deleteUser(authData.user.id)
+  return { message: 'Erro ao criar administrador. Tente novamente.' }
+}
+```
+
+---
+
+[SUGGESTION] `view.tsx` — `<select>` nativo pode ter background branco em alguns navegadores
+
+`bg-transparent` no `<select>` nativo não é respeitado de forma consistente em todos os browsers (especialmente Safari e Windows). Pode exibir fundo branco dentro de um contexto dark mode. Não é crítico agora (sem dark mode confirmado), mas sinalizo para quando o tema for implementado.
+
+---
+
+[SUGGESTION] `actions.ts` — mensagem de erro genérica do Supabase pode vazar informação
+
+`authError?.message` do Supabase pode retornar strings em inglês como `"User already registered"`. Considerar mapear para mensagens em português antes de retornar:
+```typescript
+const isEmailTaken = authError?.message?.includes('already registered')
+return { message: isEmailTaken ? 'Este e-mail já está em uso.' : 'Erro ao criar conta.' }
+```
+
+---
+
+[QUESTION] `viewModel.tsx` — `router.back()` no cancelar
+
+Se o usuário acessar `/cms/dashboard/admins/novo` diretamente (ex: via bookmark), `router.back()` vai navegar para fora do CMS. Isso é comportamento esperado, ou deveria haver um fallback para `/cms/dashboard`?
+
+---
+
+[PRAISE] Separação view / viewModel executada corretamente pela primeira vez no CMS
+
+Esta é a primeira feature do CMS a usar `viewModel.tsx` separado, seguindo o ADR-004 na íntegra. O `view.tsx` é puro JSX + Shadcn — zero lógica. O `viewModel.tsx` encapsula `useActionState`, `useForm`, `useRouter` e `handleCancel`. Vai servir de referência para refatorar as features existentes (`/cms/register`, `/cms/login`).
+
+---
+
+[PRAISE] `ROLE_OPTIONS as const` + `key={opt.value}` — padrão correto para listas estáticas
+
+Array de opções definido como `as const` fora do componente (não recriado a cada render) com `key` estável usando `opt.value`. Pequeno detalhe, mas revela atenção ao desempenho mesmo em listas pequenas.
+
+---
+
+[PRAISE] `criarAdmin` com validação Zod server-side antes de tocar no Supabase
+
+O Server Action valida o FormData com Zod antes de qualquer chamada ao banco. Mesmo que o cliente quebre a validação (JS desativado, request manual), os dados nunca chegam ao Supabase sem passar pelo schema. Defesa em profundidade aplicada corretamente.
+
+---
+
+## Decisão
+
+**Requer correção do BLOCKER** — usuário auth órfão é um problema de consistência de dados real.

--- a/docs/.squads/sessions/portal-nexora/state.json
+++ b/docs/.squads/sessions/portal-nexora/state.json
@@ -1,15 +1,15 @@
 {
   "feature": "portal-nexora",
   "created_at": "2026-04-25T00:00:00Z",
-  "updated_at": "2026-04-30T00:04:00Z",
+  "updated_at": "2026-04-30T13:00:00Z",
   "squads": {
     "frontend-001": {
       "domain": "frontend",
       "pipeline": "feature-development",
-      "started_at": "2026-04-30T00:00:00Z",
-      "completed_at": "2026-04-30T00:04:00Z",
+      "started_at": "2026-04-30T12:00:00Z",
+      "completed_at": "2026-04-30T13:00:00Z",
       "status": "completed",
-      "completed_steps": ["01-gate-integridade", "02-arquitetura", "03-checkpoint-design", "04-implementacao", "05-review", "06-docs", "update-task"],
+      "completed_steps": ["01-gate-integridade", "02-arquitetura", "03-checkpoint-design", "04-implementacao", "05-review", "06-docs"],
       "current_step": null,
       "suspended_at": null
     },

--- a/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/view.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/view.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { AdminProfile, AdminRole } from '@/lib/supabase/types'
+
+type Props = {
+  admins: AdminProfile[]
+}
+
+const ROLE_LABEL: Record<AdminRole, string> = {
+  admin: 'Admin',
+  content_creator: 'Content Creator',
+  professor: 'Professor',
+}
+
+const ROLE_VARIANT: Record<AdminRole, 'default' | 'secondary' | 'outline'> = {
+  admin: 'default',
+  content_creator: 'secondary',
+  professor: 'outline',
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+}
+
+export function AdminsListView({ admins }: Props) {
+  return (
+    <div className={cn(['space-y-6'])}>
+      <div className={cn(['flex items-center justify-between'])}>
+        <div>
+          <h2 className={cn(['text-2xl font-bold tracking-tight'])}>Administradores</h2>
+          <p className={cn(['text-sm text-muted-foreground'])}>
+            Gerencie os usuários com acesso ao CMS.
+          </p>
+        </div>
+        <Button render={<Link href="/cms/dashboard/admins/novo" />}>
+          Criar administrador
+        </Button>
+      </div>
+
+      {admins.length === 0 ? (
+        <div
+          className={cn([
+            'rounded-lg border border-dashed p-12 text-center text-sm text-muted-foreground',
+          ])}
+        >
+          Nenhum administrador cadastrado ainda.
+        </div>
+      ) : (
+        <div className={cn(['rounded-lg border overflow-hidden'])}>
+          <table className={cn(['w-full text-sm'])}>
+            <thead>
+              <tr className={cn(['border-b bg-muted/50'])}>
+                <th
+                  className={cn(['px-4 py-3 text-left font-medium text-muted-foreground'])}
+                >
+                  Nome
+                </th>
+                <th
+                  className={cn(['px-4 py-3 text-left font-medium text-muted-foreground'])}
+                >
+                  Permissão
+                </th>
+                <th
+                  className={cn([
+                    'px-4 py-3 text-left font-medium text-muted-foreground hidden sm:table-cell',
+                  ])}
+                >
+                  Desde
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {admins.map((admin, index) => (
+                <tr
+                  key={admin.id}
+                  className={cn(['border-b last:border-0', { 'bg-muted/20': index % 2 !== 0 }])}
+                >
+                  <td className={cn(['px-4 py-3 font-medium'])}>{admin.full_name}</td>
+                  <td className={cn(['px-4 py-3'])}>
+                    <Badge variant={ROLE_VARIANT[admin.role]}>
+                      {ROLE_LABEL[admin.role]}
+                    </Badge>
+                  </td>
+                  <td
+                    className={cn([
+                      'px-4 py-3 text-muted-foreground hidden sm:table-cell',
+                    ])}
+                  >
+                    {formatDate(admin.created_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/actions.ts
+++ b/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/actions.ts
@@ -1,11 +1,11 @@
 'use server'
 
 import { redirect } from 'next/navigation'
-import { createClient } from '@/lib/supabase/server'
-import { registerSchema } from './schema'
+import { createAdminClient } from '@/lib/supabase/admin'
 import type { ActionState } from '@/lib/supabase/types'
+import { novoAdminSchema } from './schema'
 
-export async function signUp(
+export async function criarAdmin(
   _prevState: ActionState,
   formData: FormData
 ): Promise<ActionState> {
@@ -14,37 +14,43 @@ export async function signUp(
     email: formData.get('email'),
     password: formData.get('password'),
     confirm_password: formData.get('confirm_password'),
+    role: formData.get('role'),
   }
 
-  const parsed = registerSchema.safeParse(raw)
+  const parsed = novoAdminSchema.safeParse(raw)
 
   if (!parsed.success) {
     return {
-      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+      errors: parsed.error.flatten((issue) => issue.message).fieldErrors as Record<
+        string,
+        string[]
+      >,
     }
   }
 
-  const supabase = await createClient()
+  const adminClient = createAdminClient()
 
-  const { data: authData, error: authError } = await supabase.auth.signUp({
+  const { data: authData, error: authError } = await adminClient.auth.admin.createUser({
     email: parsed.data.email,
     password: parsed.data.password,
+    email_confirm: true,
   })
 
   if (authError || !authData.user) {
     return { message: authError?.message ?? 'Erro ao criar conta.' }
   }
 
-  const { error: profileError } = await supabase
+  const { error: profileError } = await adminClient
     .from('profiles')
     .insert({
       user_id: authData.user.id,
       full_name: parsed.data.full_name,
-      role: 'content_creator',
+      role: parsed.data.role,
     })
 
   if (profileError) {
-    return { message: 'Conta criada, mas erro ao salvar perfil.' }
+    await adminClient.auth.admin.deleteUser(authData.user.id)
+    return { message: 'Erro ao criar administrador. Tente novamente.' }
   }
 
   redirect('/cms/dashboard')

--- a/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/schema.ts
+++ b/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const novoAdminSchema = z
+  .object({
+    full_name: z.string().min(2, 'Nome deve ter no mínimo 2 caracteres'),
+    email: z.string().email('E-mail inválido'),
+    password: z.string().min(8, 'Senha deve ter no mínimo 8 caracteres'),
+    confirm_password: z.string(),
+    role: z.enum(['admin', 'content_creator', 'professor']),
+  })
+  .refine((data) => data.password === data.confirm_password, {
+    message: 'As senhas não coincidem',
+    path: ['confirm_password'],
+  })
+
+export type NovoAdminFormData = z.infer<typeof novoAdminSchema>

--- a/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/view.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/view.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { useNovoAdminViewModel } from './viewModel'
+
+const ROLE_OPTIONS = [
+  { value: 'content_creator', label: 'Content Creator' },
+  { value: 'professor', label: 'Professor' },
+  { value: 'admin', label: 'Admin' },
+] as const
+
+export function NovoAdminView() {
+  const { form, formAction, isPending, state, handleCancel } = useNovoAdminViewModel()
+  const {
+    register,
+    formState: { errors },
+  } = form
+
+  return (
+    <div className={cn(['mx-auto max-w-lg py-8 px-4'])}>
+      <h1 className={cn(['text-2xl font-bold tracking-tight mb-2'])}>
+        Novo administrador
+      </h1>
+      <p className={cn(['text-sm text-muted-foreground mb-8'])}>
+        Crie uma conta de acesso ao CMS para um novo membro da equipe.
+      </p>
+
+      <form action={formAction} className={cn(['space-y-5'])}>
+        <div className={cn(['space-y-1.5'])}>
+          <Label htmlFor="full_name">Nome completo</Label>
+          <Input
+            id="full_name"
+            type="text"
+            placeholder="João Silva"
+            autoComplete="name"
+            {...register('full_name')}
+            className={cn([
+              { 'border-destructive': errors.full_name || state?.errors?.full_name },
+            ])}
+          />
+          {(errors.full_name || state?.errors?.full_name) && (
+            <p className={cn(['text-xs text-destructive'])}>
+              {errors.full_name?.message ?? state?.errors?.full_name?.[0]}
+            </p>
+          )}
+        </div>
+
+        <div className={cn(['space-y-1.5'])}>
+          <Label htmlFor="email">E-mail</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="usuario@nexora.com"
+            autoComplete="email"
+            {...register('email')}
+            className={cn([
+              { 'border-destructive': errors.email || state?.errors?.email },
+            ])}
+          />
+          {(errors.email || state?.errors?.email) && (
+            <p className={cn(['text-xs text-destructive'])}>
+              {errors.email?.message ?? state?.errors?.email?.[0]}
+            </p>
+          )}
+        </div>
+
+        <div className={cn(['space-y-1.5'])}>
+          <Label htmlFor="password">Senha temporária</Label>
+          <Input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            autoComplete="new-password"
+            {...register('password')}
+            className={cn([
+              { 'border-destructive': errors.password || state?.errors?.password },
+            ])}
+          />
+          {(errors.password || state?.errors?.password) && (
+            <p className={cn(['text-xs text-destructive'])}>
+              {errors.password?.message ?? state?.errors?.password?.[0]}
+            </p>
+          )}
+        </div>
+
+        <div className={cn(['space-y-1.5'])}>
+          <Label htmlFor="confirm_password">Confirmar senha</Label>
+          <Input
+            id="confirm_password"
+            type="password"
+            placeholder="••••••••"
+            autoComplete="new-password"
+            {...register('confirm_password')}
+            className={cn([
+              {
+                'border-destructive':
+                  errors.confirm_password || state?.errors?.confirm_password,
+              },
+            ])}
+          />
+          {(errors.confirm_password || state?.errors?.confirm_password) && (
+            <p className={cn(['text-xs text-destructive'])}>
+              {errors.confirm_password?.message ??
+                state?.errors?.confirm_password?.[0]}
+            </p>
+          )}
+        </div>
+
+        <div className={cn(['space-y-1.5'])}>
+          <Label htmlFor="role">Permissão</Label>
+          <select
+            id="role"
+            {...register('role')}
+            className={cn([
+              'h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+              { 'border-destructive': errors.role || state?.errors?.role },
+            ])}
+          >
+            {ROLE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {(errors.role || state?.errors?.role) && (
+            <p className={cn(['text-xs text-destructive'])}>
+              {errors.role?.message ?? state?.errors?.role?.[0]}
+            </p>
+          )}
+        </div>
+
+        {state?.message && (
+          <p className={cn(['text-sm text-destructive'])}>{state.message}</p>
+        )}
+
+        <div className={cn(['flex gap-3 pt-2'])}>
+          <Button type="submit" disabled={isPending} className={cn(['flex-1'])}>
+            {isPending ? 'Criando conta…' : 'Criar administrador'}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+          >
+            Cancelar
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/viewModel.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/viewModel.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useActionState } from 'react'
+import { useForm, type UseFormReturn } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useRouter } from 'next/navigation'
+import { criarAdmin } from './actions'
+import { novoAdminSchema, type NovoAdminFormData } from './schema'
+import type { ActionState } from '@/lib/supabase/types'
+
+type NovoAdminViewModel = {
+  form: UseFormReturn<NovoAdminFormData>
+  formAction: (payload: FormData) => void
+  isPending: boolean
+  state: ActionState
+  handleCancel: () => void
+}
+
+export function useNovoAdminViewModel(): NovoAdminViewModel {
+  const router = useRouter()
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    criarAdmin,
+    undefined
+  )
+
+  const form = useForm<NovoAdminFormData>({
+    resolver: zodResolver(novoAdminSchema),
+    defaultValues: {
+      full_name: '',
+      email: '',
+      password: '',
+      confirm_password: '',
+      role: 'content_creator',
+    },
+  })
+
+  function handleCancel() {
+    router.back()
+  }
+
+  return { form, formAction, isPending, state, handleCancel }
+}

--- a/src/app/(cms)/cms/dashboard/admins/novo/page.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/novo/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { NovoAdminView } from './_features/NovoAdmin/view'
+
+export const metadata: Metadata = {
+  title: 'Novo Administrador — NEXORA CMS',
+}
+
+export default function NovoAdminPage() {
+  return <NovoAdminView />
+}

--- a/src/app/(cms)/cms/dashboard/admins/page.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next'
+import { createClient } from '@/lib/supabase/server'
+import type { AdminProfile } from '@/lib/supabase/types'
+import { AdminsListView } from './_features/AdminsList/view'
+
+export const metadata: Metadata = {
+  title: 'Administradores — NEXORA CMS',
+}
+
+export default async function AdminsPage() {
+  const supabase = await createClient()
+
+  const { data } = await supabase
+    .from('profiles')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  const admins: AdminProfile[] = data ?? []
+
+  return <AdminsListView admins={admins} />
+}

--- a/src/app/(cms)/cms/dashboard/layout.tsx
+++ b/src/app/(cms)/cms/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
-import { createClient } from '@/lib/supabase/server'
 import { CMSShell } from '@/components/cms/CMSShell'
+import { createClient } from '@/lib/supabase/server'
 
 export default async function DashboardLayout({
   children,
@@ -17,7 +17,7 @@ export default async function DashboardLayout({
   }
 
   const { data: profile } = await supabase
-    .from('admin_profiles')
+    .from('profiles')
     .select('*')
     .eq('user_id', user.id)
     .single()

--- a/src/components/cms/Sidebar/SidebarNav.tsx
+++ b/src/components/cms/Sidebar/SidebarNav.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { BookOpen, FileText, LayoutDashboard, Users } from "lucide-react";
+import { BookOpen, FileText, LayoutDashboard, ShieldCheck } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
-  { label: "Dashboard", href: "/cms/dashboard", icon: LayoutDashboard },
-  { label: "Conteúdos", href: "/cms/contents", icon: FileText },
-  { label: "Cursos", href: "/cms/courses", icon: BookOpen },
-  { label: "Usuários", href: "/cms/users", icon: Users },
+  { label: "Dashboard", href: "/cms/dashboard", icon: LayoutDashboard, exact: true },
+  { label: "Conteúdos", href: "/cms/contents", icon: FileText, exact: false },
+  { label: "Cursos", href: "/cms/courses", icon: BookOpen, exact: false },
+  { label: "Administradores", href: "/cms/dashboard/admins", icon: ShieldCheck, exact: false },
 ];
 
 export function SidebarNav() {
@@ -17,8 +17,8 @@ export function SidebarNav() {
 
   return (
     <nav className={cn("flex flex-col gap-1 px-2")}>
-      {NAV_ITEMS.map(({ label, href, icon: Icon }) => {
-        const active = pathname.startsWith(href);
+      {NAV_ITEMS.map(({ label, href, icon: Icon, exact }) => {
+        const active = exact ? pathname === href : pathname.startsWith(href);
         return (
           <Link
             key={href}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js'
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}


### PR DESCRIPTION
## Summary

- Página `/cms/dashboard/admins` com tabela de admins (nome, role badge, data de criação) e empty state
- Formulário `/cms/dashboard/admins/novo` com MVVM completo (view + viewModel + schema + actions) seguindo ADR-004
- `createAdminClient()` usando service role key para Supabase Admin API (`auth.admin.createUser`)
- Rollback automático via `deleteUser` se a inserção de profile falhar após criação do auth user
- Correção: tabela renomeada de `admin_profiles` → `profiles` em todos os arquivos
- SidebarNav atualizado com item "Administradores" (ícone ShieldCheck) e active detection corrigida para `/cms/dashboard`

## Test plan

- [ ] Login com `admin@gmail.com` e navegar para Administradores no sidebar
- [ ] Verificar tabela listando o admin existente com badge "Admin"
- [ ] Clicar "Criar administrador" e preencher o formulário
- [ ] Verificar que o novo usuário aparece em `profiles` no Supabase e na tabela
- [ ] Verificar que "Dashboard" no sidebar não fica ativo ao entrar em /admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)