### PR TITLE
feat: fluxo completo de eventos — CMS + plataforma pública

### DIFF
--- a/.opencode/commands/setup/from-code.md
+++ b/.opencode/commands/setup/from-code.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/from-code.md

--- a/.opencode/commands/setup/squad.md
+++ b/.opencode/commands/setup/squad.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/squad.md

--- a/.synapos/.manifest.json
+++ b/.synapos/.manifest.json
@@ -1,8 +1,8 @@
 {
   "framework": {
     "name": "synapos",
-    "version": "2.6.1",
-    "released_at": "2026-04-03"
+    "version": "2.7.0",
+    "released_at": "2026-05-06"
   },
   "best_practices": {
     "catalog": "1.1.0",
@@ -25,8 +25,9 @@
   },
   "core": {
     "orchestrator": "1.6.1",
-    "pipeline_runner": "2.3.0",
+    "pipeline_runner": "2.5.0",
     "gate_system": "1.5.0",
+    "change_guard": "1.0.0",
     "model_adapter": "1.1.0",
     "skills_engine": "1.1.0",
     "versioning": "1.1.0",

--- a/.synapos/core/change-guard.md
+++ b/.synapos/core/change-guard.md
@@ -1,0 +1,147 @@
+---
+name: synapos-change-guard
+description: Protocolo de rastreamento de alterações — reporta arquivos modificados, trechos alterados e o que não foi preciso alterar
+version: 1.0.0
+---
+
+# SYNAPOS CHANGE GUARD v1.0.0
+
+> Garante visibilidade sobre o que foi tocado em cada step de execução.
+> Responde três perguntas: o que foi alterado? qual trecho? o que não precisou ser alterado?
+
+---
+
+## PROTOCOLO DO AGENT
+
+Todo agent executado em steps `subagent` ou `inline` que interaja com arquivos do projeto **DEVE** incluir um bloco `[CHANGE GUARD]` ao final de seu output.
+
+### Instrução injetada no prompt do agent
+
+```
+📋 CHANGE GUARD — instrução obrigatória
+
+Ao concluir sua tarefa, inclua ao final do output o seguinte bloco.
+Inclua TODOS os arquivos que você abriu durante a execução — alterados ou não.
+
+---
+📋 [CHANGE GUARD]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✏️  ALTERADOS ({N} arquivo(s))
+  {caminho/do/arquivo.ext}
+    • L{start}–L{end} — {o que foi alterado}
+    (repita por trecho)
+
+👁️  REVISADOS · SEM ALTERAÇÃO ({N} arquivo(s))
+  {caminho/do/arquivo.ext} — {motivo: já estava correto | não aplicável | fora do escopo deste step}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{N} alterado(s) · {N} sem alteração necessária
+---
+
+Regras para preenchimento:
+- Nunca omita um arquivo consultado, mesmo que a visita tenha sido rápida
+- Para arquivos alterados: liste cada trecho separado com linha aproximada
+- Para arquivos não alterados: uma frase objetiva sobre o motivo basta
+- Se nenhum arquivo foi acessado: escreva "CHANGE GUARD — nenhum arquivo acessado neste step"
+- Arquivos de session (.squads/sessions/) são excluídos — reportar apenas arquivos do projeto
+```
+
+---
+
+## COMO O PIPELINE-RUNNER USA O CHANGE GUARD
+
+### Extração do bloco
+
+Após receber o output do agent (antes de passar ao GATE-3), o pipeline-runner:
+
+1. Procura pelo bloco entre `📋 [CHANGE GUARD]` e o segundo `━━━` ao final
+2. Extrai e armazena o conteúdo do bloco como `[CHANGE_GUARD_REPORT]`
+3. Remove o bloco do output antes de salvar o `output_file` (o change guard não faz parte do artefato)
+4. Exibe o relatório após a linha `✅ {Nome do Step} — concluído`
+
+### Log de exibição (após step completo)
+
+```
+📋 [CHANGE GUARD] — {nome do step}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✏️  ALTERADOS (2 arquivo(s))
+  src/auth/login.ts
+    • L12–L28 — adicionada validação JWT
+    • L45 — corrigido tipo de retorno
+
+👁️  REVISADOS · SEM ALTERAÇÃO (1 arquivo)
+  src/auth/middleware.ts — validações já implementadas corretamente
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+2 alterado(s) · 1 sem alteração necessária
+```
+
+### Se o bloco estiver ausente
+
+```
+⚠️ [CHANGE GUARD] bloco ausente no output do step "{step-id}" — rastreamento indisponível.
+```
+
+Não bloqueie o pipeline — apenas logue o aviso e continue.
+
+### Persistência em change-log.md
+
+Se `squad.yaml` declara `change_log: true`, o pipeline-runner persiste os relatórios em:
+
+```
+docs/.squads/sessions/{feature-slug}/change-log.md
+```
+
+Formato append:
+```markdown
+## {step-id} — {YYYY-MM-DD HH:MM}
+Squad: {squad-slug} · Agent: {agent-id}
+
+✏️  ALTERADOS
+  {conteúdo extraído do bloco}
+
+👁️  REVISADOS · SEM ALTERAÇÃO
+  {conteúdo extraído do bloco}
+```
+
+---
+
+## ATIVAÇÃO E DESATIVAÇÃO
+
+O CHANGE GUARD é **ativo por padrão** em todos os steps com `execution: subagent` ou `execution: inline`.
+
+### Desativar por squad
+
+```yaml
+# squad.yaml
+change_guard: false
+```
+
+### Desativar por step
+
+```yaml
+# pipeline.yaml
+- id: step-id
+  name: "Formatar Saída"
+  change_guard: false   # sem rastreamento — step não toca arquivos do projeto
+```
+
+### Ativar persistência em log
+
+```yaml
+# squad.yaml
+change_log: true   # padrão: false
+```
+
+---
+
+## REGRAS
+
+| Regra | Descrição |
+|-------|-----------|
+| **Ativo por padrão** | Todos os steps inline/subagent, a menos que explicitamente desativado |
+| **Não bloqueia** | Ausência do bloco gera aviso, nunca falha de gate |
+| **Não faz parte do artefato** | O bloco é extraído antes de salvar o output_file |
+| **Inclui não-alterados** | Arquivo revisado mas não modificado é tão relevante quanto o alterado |
+| **Linha aproximada aceita** | Intervalos aproximados são válidos — precisão exata não é exigida |
+| **Motivo obrigatório** | Para arquivos não alterados, uma frase de razão é sempre necessária |
+| **Session files excluídos** | Arquivos em docs/.squads/sessions/ não entram no relatório |
+| **Log persistente opcional** | Ativado via change_log: true no squad.yaml |

--- a/.synapos/core/orchestrator.md
+++ b/.synapos/core/orchestrator.md
@@ -309,17 +309,46 @@ Quando o usuário escolhe um squad ativo no PASSO 4:
 
 ```
 AskUserQuestion({
-  question: "Role {squad-slug} carregado.\nFeature: {feature-slug}\n\nRoles que já trabalharam: {lista}\n\nO que você quer fazer?",
+  question: "Role {squad-slug} carregado.\nFeature atual: {feature-slug}\n\nRoles que já trabalharam: {lista}\n\nO que você quer fazer?",
   options: [
-    { label: "🔄 Nova execução", description: "Executar novamente (manter contexto)" },
+    { label: "🔄 Continuar nesta feature", description: "Executar novamente em: {feature-slug}" },
+    { label: "✨ Nova feature", description: "Iniciar uma feature diferente (cria nova session)" },
     { label: "🧠 Ver memória", description: "Abrir memories.md da feature" },
-    { label: "📂 Ver arquivos", description: "Ver arquivos da session" },
-    { label: "⏸️ Pausar", description: "Pausar/arquivar role" }
+    { label: "📂 Ver arquivos", description: "Ver arquivos da session" }
   ]
 })
 ```
 
-Para "Nova execução" → pule para PASSO 5.3 com o `[EXECUTION_MODE]` lido do squad.yaml.
+**"Continuar nesta feature"** → pule para PASSO 5.3 com `[EXECUTION_MODE]` do squad.yaml e `feature` inalterado.
+
+**"✨ Nova feature"** → siga o protocolo abaixo antes de ir ao PASSO 5.3.
+
+### Nova feature em squad existente
+
+1. Pergunte o nome da nova feature:
+   ```
+   AskUserQuestion({
+     question: "Qual é o nome ou slug da nova feature?\n\nExemplos: auth-refactor, checkout-v2, fix-payment-flow",
+     options: [
+       { label: "✏️ Digitar o nome", description: "Informe no chat abaixo" }
+     ]
+   })
+   ```
+   Aguarde a resposta do usuário. Normalize para slug: minúsculas, hífens, sem espaços (ex: "Auth Refactor" → "auth-refactor").
+
+2. Atualize `squad.yaml`:
+   - `feature: {novo-slug}`
+   - `session: {novo-slug}`
+   - `status: active`
+   - `updated_at: {agora ISO}`
+
+3. Log:
+   ```
+   ✨ Nova feature iniciada: {novo-slug}
+   Session será criada em: docs/.squads/sessions/{novo-slug}/
+   ```
+
+4. Pule para PASSO 5.3 — o pipeline-runner criará a session automaticamente se não existir (seção 1.4).
 
 ---
 

--- a/.synapos/core/pipeline-runner.md
+++ b/.synapos/core/pipeline-runner.md
@@ -3,7 +3,7 @@ name: synapos-pipeline-runner
 description: Engine de execução de pipelines — gerencia steps, agents, vetos e revisões
 ---
 
-# SYNAPOS PIPELINE RUNNER v2.4.0
+# SYNAPOS PIPELINE RUNNER v2.5.0
 
 > Responsável por executar pipelines de squads step-by-step.
 > Chamado pelo orchestrator após criação ou carregamento de um squad.
@@ -17,6 +17,9 @@ description: Engine de execução de pipelines — gerencia steps, agents, vetos
 > v2.4: plan.md é artefato estático (state.json é fonte única de progresso),
 > architecture.md cacheado em memória por pipeline run, checkpoints da
 > pré-execução consolidados em um único checkpoint final.
+>
+> v2.5: CHANGE GUARD — rastreamento de alterações por step. Todo step inline/subagent
+> reporta arquivos alterados (com trechos), arquivos revisados sem alteração e motivo.
 
 ---
 
@@ -685,6 +688,63 @@ Após receber o output do agent, antes de passar para GATE-3, verifique se o out
   - Se **Atualizar**: registre `suspended_at` com o step atual, oriente o usuário a editar `architecture.md` e retomar via `/init`. Ao retomar, `[ARCHITECTURE_CACHE]` é invalidado (novo pipeline run) — architecture.md é relido do disco.
 - **Sem violação** → continue para GATE-3 normalmente.
 
+### 2.3c — CHANGE GUARD (steps inline/subagent, ativo por padrão)
+
+Execute este guard em **todos** os steps com `execution: subagent` ou `execution: inline`, a menos que o step declare `change_guard: false` ou o squad.yaml declare `change_guard: false`.
+
+**Verifique a ativação:**
+1. Se `squad.yaml.change_guard: false` → pule esta seção inteiramente.
+2. Se `pipeline.yaml` → step atual tem `change_guard: false` → pule esta seção.
+3. Caso contrário → ativo.
+
+**Injetar instrução no prompt do agent** (após SCOPE GUARD, antes da instrução do step):
+
+```
+📋 CHANGE GUARD — instrução obrigatória
+
+Ao concluir sua tarefa, inclua ao final do output o seguinte bloco.
+Inclua TODOS os arquivos que você abriu durante a execução — alterados ou não.
+
+---
+📋 [CHANGE GUARD]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✏️  ALTERADOS ({N} arquivo(s))
+  {caminho/do/arquivo.ext}
+    • L{start}–L{end} — {o que foi alterado}
+
+👁️  REVISADOS · SEM ALTERAÇÃO ({N} arquivo(s))
+  {caminho/do/arquivo.ext} — {motivo: já estava correto | não aplicável | fora do escopo deste step}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{N} alterado(s) · {N} sem alteração necessária
+---
+
+Regras:
+- Nunca omita um arquivo consultado, mesmo que a visita tenha sido rápida
+- Para arquivos alterados: liste cada trecho com linha aproximada
+- Para arquivos não alterados: uma frase objetiva basta
+- Arquivos de session (docs/.squads/sessions/) não entram no relatório
+- Se nenhum arquivo do projeto foi acessado: escreva "CHANGE GUARD — nenhum arquivo acessado neste step"
+```
+
+**Após receber o output do agent:**
+
+1. Procure o bloco entre `📋 [CHANGE GUARD]` e o segundo `━━━` ao final
+2. Extraia e armazene como `[CHANGE_GUARD_REPORT]` para exibição no passo 2.8
+3. **Remova o bloco do output** antes de salvar o `output_file` — o change guard não faz parte do artefato
+4. Se o bloco **não for encontrado**: logue `⚠️ [CHANGE GUARD] bloco ausente no step "{step-id}" — rastreamento indisponível` e continue normalmente
+
+**Persistência (se `squad.yaml.change_log: true`):**
+
+Faça append em `docs/.squads/sessions/{feature-slug}/change-log.md`:
+```markdown
+## {step-id} — {YYYY-MM-DD HH:MM}
+Squad: {squad-slug} · Agent: {agent-id}
+
+{conteúdo de [CHANGE_GUARD_REPORT]}
+```
+
+---
+
 ### 2.4 — Executar por modo
 
 **`execution: checkpoint`** — pausa para decisão do usuário. Use menu interativo:
@@ -839,6 +899,17 @@ Atualize `state.json` (via escrita atômica — veja 1.4c):
 ```
 ✅ {Nome do Step} — concluído
 ```
+
+**Se `[CHANGE_GUARD_REPORT]` foi capturado no passo 2.3c**, exiba imediatamente após a linha de conclusão:
+
+```
+📋 [CHANGE GUARD] — {Nome do Step}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{conteúdo de [CHANGE_GUARD_REPORT]}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Limpe `[CHANGE_GUARD_REPORT]` após exibição — o relatório é por step, não acumulativo.
 
 ---
 
@@ -1045,3 +1116,7 @@ Substitua `{feature-slug}` e `{squad-slug}` pelos valores reais antes de injetar
 | **Escopo expandido = [DECISÃO PENDENTE]** | Se agent precisar de arquivo fora do escopo, sinaliza e aguarda aprovação — nunca expande silenciosamente |
 | **SCOPE GUARD pergunta, não rejeita** | Violação de escopo → AskUserQuestion imediato (autorizar / rejeitar / editar architecture.md). Nunca auto-rejeita — a decisão é sempre do humano |
 | **architecture.md cacheado por run** | Primeira leitura (via SCOPE GUARD ou needs_architecture) carrega e armazena em `[ARCHITECTURE_CACHE]`. Steps subsequentes reutilizam o cache durante o mesmo pipeline run |
+| **CHANGE GUARD ativo por padrão** | Todos os steps inline/subagent injetam instrução de rastreamento. Agent reporta arquivos alterados (com trechos) e revisados sem alteração. Ausência do bloco gera aviso, nunca falha |
+| **CHANGE GUARD não polui artefato** | Bloco `[CHANGE GUARD]` é extraído do output antes de salvar output_file — nunca contamina o conteúdo gerado |
+| **CHANGE GUARD desativável** | `change_guard: false` em squad.yaml (todo o squad) ou em step no pipeline.yaml (step específico) |
+| **change-log.md opcional** | `change_log: true` em squad.yaml persiste relatórios em `docs/.squads/sessions/{feature-slug}/change-log.md` |

--- a/docs/.squads/sessions/portal-nexora/architecture.md
+++ b/docs/.squads/sessions/portal-nexora/architecture.md
@@ -1,347 +1,290 @@
-# Decisão Arquitetural: Identidade Visual + Redesign da Home
+# Decisão Arquitetural: Fluxo de Eventos (CMS + Plataforma)
 
-**Data:** 2026-05-02
-**Agent:** Ana Arquitetura + Úrsula UI
-**Squad:** frontend-001
+**Data:** 2026-05-06
+**Agent:** Ana Arquitetura
 
 ---
 
 ## Entendimento da Task
 
-Redesign completo da home page do Portal Nexora como protótipo de identidade visual.
-Análise de concorrentes (Udemy, Alura, Hotmart) para extrair melhores práticas de UI/UX.
-Foco em posicionamento diferenciado: plataforma educacional de impacto social — nem tão corporativa quanto Udemy, nem tão técnica quanto Alura, mais calorosa que Hotmart.
-
----
-
-## Análise Competitiva — Insights Extraídos
-
-### Udemy
-- **O que funciona:** Paleta neutra (branco/cinza) com accent vibrante que faz o CTA "saltar". Cards com thumbnail, social proof (N alunos). Navbar com busca proeminente.
-- **O que evitar:** Densidade visual excessiva, sensação de marketplace genérico sem personalidade.
-
-### Alura
-- **O que funciona:** Identidade visual forte (fundo navy escuro + tema "oceânico"). Destaque enorme nos números (2.212 cursos, 120k comunidade). CTAs duplos (explorar + matricular). Seção interativa de carreiras.
-- **O que evitar:** Dark background exige muito cuidado de contraste — peso visual alto.
-
-### Hotmart
-- **O que funciona:** Social proof com números enormes (50B+ em vendas, 4.6★ com 200k avaliações) **acima do fold**. Gradiente energético. CTA repetido estrategicamente. Espaçamento generoso.
-- **O que evitar:** Foco em produtor/vendedor não se aplica ao posicionamento social de NEXORA.
-
-### Síntese — O que NEXORA deve incorporar
-
-| Prática | Origem | Aplicação |
-|---|---|---|
-| Social proof numérico no hero | Hotmart | Stats (+500 alunos, +30 projetos, +15 parceiros) no próprio hero |
-| Accent vibrante em CTAs | Udemy | Amber `#F59E0B` como cor de ação primária |
-| Identidade de cor forte e própria | Alura | Deep Teal como primary — diferente dos 3 concorrentes |
-| Espaçamento generoso entre seções | Hotmart | `py-20` mínimo, `py-28` no hero |
-| Depoimentos com foto + contexto | Alura | Nova seção TestimonialsSection |
-| Hero split-layout | Todos | Texto à esquerda, visual/stats à direita (desktop) |
-
----
-
-## Sistema de Design — Identidade Visual NEXORA
-
-### ADR-VIS-001: Paleta de Cores da Marca
-
-**Contexto:** `globals.css` atual usa tokens Shadcn padrão (preto/branco), sem identidade de marca. Os componentes usam classes Tailwind hardcoded (`blue-900`, `emerald-500`) sem sistema coeso.
-
-**Decisão:** Definir identidade **Deep Teal + Warm Amber** no `globals.css` via CSS custom properties, remapeando os tokens `--primary` e `--accent` do Shadcn.
-
-**Alternativas rejeitadas:**
-- Manter `blue-900`/`emerald-500` inline — sem coesão, difícil manutenção e sem diferenciação
-- Roxo (Udemy) — já ocupado pelos líderes de mercado
-- Laranja (Hotmart) — transmite venda agressiva, não impacto social
-
-**Paleta definida (valores oklch compatíveis com Tailwind v4):**
-
-```
-NEXORA Brand Colors
-─────────────────────────────────────────────────────────────
-Role              Nome           OKLCH aprox.   Hex equiv.
-─────────────────────────────────────────────────────────────
---brand-primary   Deep Teal      oklch(0.45 0.12 175)  #0F766E  → confiança+tech+social
---brand-primary-d Dark Teal      oklch(0.38 0.11 175)  #0D5E57  → hover states
---brand-primary-l Light Teal     oklch(0.96 0.04 175)  #CCFBF1  → bg suave, badges
---brand-teal-hero Hero BG Teal   oklch(0.20 0.07 175)  #0D3D37  → hero dark bg
---brand-accent    Warm Amber     oklch(0.75 0.16 85)   #F59E0B  → CTAs, destaques
---brand-accent-d  Deep Amber     oklch(0.65 0.16 85)   #D97706  → hover do CTA
---brand-heading   Slate 900      oklch(0.13 0.02 240)  #0F172A  → headings
---brand-body      Slate 600      oklch(0.42 0.03 240)  #475569  → body text
---brand-bg-alt    Slate 50       oklch(0.98 0.01 240)  #F8FAFC  → fundos alternados
-─────────────────────────────────────────────────────────────
-```
-
-**Tokens Shadcn remapeados:**
-```
---primary              → brand-primary  (teal-700)
---primary-foreground   → white
-```
-
-**Consequências:**
-✅ Identidade única — Deep Teal não existe nos 3 concorrentes analisados
-✅ Teal = saúde + educação + tecnologia na psicologia das cores
-✅ Amber = calor, acessibilidade, missão social, otimismo
-⚠ `--primary` remapeado afeta todos os componentes Shadcn que usam `bg-primary` — validar CMS após implementação
-
----
-
-### ADR-VIS-002: Tipografia
-
-**Decisão:** Inter (já carregado pelo sistema/Shadcn) sem adicionar dependência nova.
-
-```
-Display (H1):  Inter Black 900,   48–60px desktop / 36px mobile
-Heading (H2):  Inter Bold 700,    32–36px
-Sub-heading:   Inter SemiBold 600, 20–24px
-Body:          Inter Regular 400,  16px, line-height 1.6
-Small/Caption: Inter Medium 500,   14px
-Badge/Label:   Inter SemiBold 600, 12px, letter-spacing 0.08em, UPPERCASE
-```
-
----
-
-### ADR-VIS-003: Reestruturação das Seções
-
-**Contexto:** Ordem atual não segue boas práticas de landing page de conversão.
-
-**Mudança de ordem:**
-
-```
-ANTES                    DEPOIS
-──────────────────────   ──────────────────────────────────────
-1. HeroSection           1. HeroSection        (split + stats inline)
-2. CursosDestaque        2. ImpactoSection     (movida para cima — social proof)
-3. ProjetosSociais       3. CursosDestaque     (cards redesenhados)
-4. ImpactoSection        4. ProjetosSociais    (nova paleta)
-5. ParceirosCTA          5. TestimonialsSection (NOVO — depoimentos)
-                         6. ParceirosCTA        (redesign — mais impacto)
-```
-
-**Justificativa:** Social proof deve aparecer antes dos cursos. Depoimentos antes do CTA final é prática universal de alta conversão (validado pelos 3 concorrentes).
+Implementar CRUD completo de eventos no CMS admin (`/cms/dashboard/eventos/`) seguindo o padrão MVVM já estabelecido no módulo de admins. Na plataforma pública, refatorar a listagem `/eventos` de dados hardcoded para busca via Supabase e criar a página de detalhe `/eventos/[slug]` como rota dinâmica nova.
 
 ---
 
 ## Estrutura de Componentes
 
+### CMS — Gestão de Eventos
+
 ```
-src/app/(publics)/(home)/
-├── page.tsx                                    ← reordenar + adicionar Testimonials
-└── _features/home/
-    ├── HeroSection.tsx                         ← redesign: split layout, teal dark bg, amber CTA
-    ├── CursosDestaque.tsx                      ← nova paleta, cards sem border-l colorida
-    ├── ProjetosSociais.tsx                     ← nova paleta teal/amber
-    ├── ImpactoSection.tsx                      ← fundo teal-50 (não dark), stats maiores
-    ├── ParceirosCTA.tsx                        ← dark teal bg, amber CTA large
-    └── TestimonialsSection.tsx                 ← NOVO: 3 cards de depoimento
+src/app/(cms)/cms/dashboard/eventos/
+├── page.tsx                                    ← Server Component: busca lista + passa props
+├── _features/EventosList/
+│   └── view.tsx                                ← Client: tabela com filtros status/tipo + link editar + delete inline
+├── novo/
+│   ├── page.tsx                                ← Server Component puro
+│   └── _features/NovoEvento/
+│       ├── view.tsx                            ← Client: formulário completo (RHF)
+│       ├── viewModel.tsx                       ← Client: useActionState, handlers de form
+│       ├── schema.ts                           ← Zod: eventoSchema
+│       └── actions.ts                          ← Server Action: criarEvento()
+└── [id]/
+    ├── page.tsx                                ← Server Component: busca evento por id + passa props
+    ├── _features/EditarEvento/
+    │   ├── view.tsx                            ← Client: mesmo form de criar, pré-populado
+    │   ├── viewModel.tsx                       ← Client: useActionState, handlers
+    │   ├── schema.ts                           ← reusar eventoSchema do novo/ (importar)
+    │   └── actions.ts                          ← Server Actions: editarEvento() + excluirEvento()
+    └── _features/DeleteEventoDialog/
+        └── view.tsx                            ← Client: confirmação inline com useTransition
 ```
 
-### Novo type (TestimonialsSection)
+### Plataforma Pública — Eventos
 
-```typescript
-type Testimonial = {
-  id: string
-  quote: string
-  author: string
-  role: string
-  avatarInitials: string
-}
+```
+src/app/(publics)/eventos/
+├── page.tsx                                    ← Server Component: busca eventos do Supabase + passa props
+├── _features/eventos/
+│   ├── HeroEventos.tsx                         ← mantido, sem alteração
+│   ├── ProximosEventos.tsx                     ← recebe Event[] do Supabase (type unificado)
+│   └── EventosGravados.tsx                     ← recebe Event[] do Supabase (type unificado)
+└── [slug]/
+    ├── page.tsx                                ← Server Component: busca evento por slug + generateMetadata
+    └── _features/EventoDetalhe/
+        └── view.tsx                            ← Client: layout de detalhe (hero, descrição, CTA)
 ```
 
 ---
 
-## Especificação Visual por Seção (Úrsula UI)
+## Schema do Banco de Dados (Supabase)
 
-### 1. HeroSection — Split Layout
+```sql
+create table public.events (
+  id          uuid primary key default gen_random_uuid(),
+  slug        text not null unique,                     -- gerado a partir do title, ex: "live-seguranca-digital"
+  title       text not null,
+  description text not null,
+  long_description text,                                -- conteúdo rico para página de detalhe
+  type        text not null check (type in ('ao_vivo', 'gravado')),
+  status      text not null default 'draft' check (status in ('draft', 'published', 'archived')),
+  scheduled_at timestamptz,                             -- null para eventos gravados
+  duration_minutes int,                                 -- duração estimada (ao vivo) ou real (gravado)
+  thumbnail_url text,                                   -- URL da imagem de capa (Storage ou externa)
+  youtube_url  text,                                    -- URL do YouTube (ao vivo ou gravado)
+  created_by  uuid references auth.users(id),
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
 
-**Desktop layout:**
-```
-┌────────────────────────────────────────────────────────────┐
-│  bg: teal-900 (#0D3D37)                py-28               │
-├────────────────────────────┬───────────────────────────────┤
-│ col-span 55%               │ col-span 45%                  │
-│                            │                               │
-│  [PLATAFORMA EDUCACIONAL]  │   [Ilustração / placeholder   │
-│  badge amber-400           │    SVG ou imagem hero]        │
-│                            │                               │
-│  H1: Tecnologia que        │   ┌───────────────────────┐  │
-│  conecta, educa e          │   │  +500    +30    +15   │  │
-│  transforma vidas          │   │ Alunos  Proj.  Parc.  │  │
-│                            │   └───────────────────────┘  │
-│  P: Projetos sociais,      │                               │
-│  cursos profission.        │                               │
-│  e impacto real.           │                               │
-│                            │                               │
-│  [Ver Cursos ▶] [Parceiro] │                               │
-└────────────────────────────┴───────────────────────────────┘
-```
+-- RLS: leitura pública para published; escrita só para autenticados
+alter table public.events enable row level security;
 
-**Estados e especificações:**
-- Background: `bg-[var(--brand-teal-hero)]` ou `bg-teal-900`
-- Badge: `text-amber-400 text-xs font-semibold tracking-widest uppercase`
-- H1: `text-5xl md:text-6xl font-black text-white leading-[1.1]`
-- Subtitle: `text-teal-200 text-lg leading-relaxed`
-- CTA primário: `bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold h-11 px-7 transition-colors`
-- CTA secundário: `border border-teal-600 text-white hover:bg-teal-800 h-11 px-7 transition-colors`
-- Stats — número: `text-amber-400 text-4xl font-black`
-- Stats — label: `text-teal-300 text-xs font-medium`
-- Divisores stats: `border-r border-teal-700`
-- Mobile: single column, visual oculto (`hidden md:block`)
+create policy "events_public_read"
+  on public.events for select
+  using (status = 'published');
 
-**Acessibilidade:**
-- `aria-labelledby="hero-title"` mantido
-- Contraste H1 (white over teal-900): > 10:1 ✅
-- Contraste amber-400 over teal-900: ~4.7:1 ✅ AA
-
----
-
-### 2. ImpactoSection — Fundo Claro
-
-**Especificações:**
-- Background: `bg-teal-50` (não dark como antes)
-- Número: `text-6xl font-black text-teal-700`
-- Label: `text-slate-600 text-sm font-medium mt-1`
-- Divisores: `border-r border-teal-200`
-- Padding: `py-16`
-
----
-
-### 3. CursosDestaque — Cards Redesenhados
-
-**Cards:**
-- Remover `border-l-4 border-l-emerald-500`
-- Adicionar `border border-slate-200 shadow-sm hover:shadow-md hover:-translate-y-1`
-- Tag de categoria: `bg-teal-100 text-teal-700 border-0`
-- Title: `text-slate-900 font-semibold`
-- CTA card: `bg-teal-700 hover:bg-teal-600 text-white w-full` (teal, não emerald)
-- Background seção: `bg-slate-50`
-
----
-
-### 4. ProjetosSociais — Nova Paleta
-
-- Background: `bg-white`
-- Border card: `border-l-4 border-l-teal-600` (manter padrão lateral, trocar cor)
-- Icon container: `bg-teal-100` → ícone `text-teal-600`
-- Title cards: `text-slate-900`
-
----
-
-### 5. TestimonialsSection — Novo Componente
-
-**Layout:**
-```
-┌────────────────────────────────────────────────────────────┐
-│  bg-white    "O que nossos alunos dizem"   py-20           │
-│  ┌──────────────────┐ ┌──────────────────┐ ┌─────────────┐│
-│  │ ★★★★★            │ │ ★★★★★            │ │ ★★★★★       ││
-│  │ "Quote do aluno  │ │ "Quote do aluno  │ │ "Quote..."  ││
-│  │  em itálico"     │ │  em itálico"     │ │             ││
-│  │                  │ │                  │ │             ││
-│  │ [AB] Nome        │ │ [CD] Nome        │ │ [EF] Nome   ││
-│  │ Curso cursado    │ │ Curso cursado    │ │ Curso       ││
-│  └──────────────────┘ └──────────────────┘ └─────────────┘│
-└────────────────────────────────────────────────────────────┘
+create policy "events_cms_write"
+  on public.events for all
+  using (auth.role() = 'authenticated');
 ```
 
-**Especificações:**
-- Background seção: `bg-white`
-- Cards: `bg-slate-50 border border-slate-200 rounded-xl p-6`
-- Stars: `text-amber-400` (5 ícones `Star` do lucide, `fill-amber-400`)
-- Quote: `text-slate-700 italic text-base leading-relaxed`
-- Avatar: `size-10 rounded-full bg-teal-700 text-white flex items-center justify-center text-sm font-bold`
-- Author name: `text-slate-900 font-semibold text-sm`
-- Role: `text-teal-600 text-xs`
-
-**Acessibilidade:**
-- Contraste quote (slate-700 over slate-50): ~6.7:1 ✅ AA
-- Avatar é decorativo — `aria-hidden="true"` no div
-
----
-
-### 6. ParceirosCTA — Dark e Imponente
-
-**Especificações:**
-- Background: `bg-teal-900` com subtle dot pattern via `bg-[radial-gradient(circle,_rgba(255,255,255,0.05)_1px,_transparent_1px)] [background-size:24px_24px]`
-- Título: `text-white text-4xl font-black`
-- Subtitle: `text-teal-200 text-lg`
-- CTA: `bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold h-14 px-10 text-lg transition-colors`
-- Padding: `py-28`
-
----
-
-## Tokens CSS a adicionar em globals.css
-
-```css
-/* Adicionar no :root — Brand NEXORA */
---brand-primary: oklch(0.45 0.12 175);
---brand-primary-dark: oklch(0.38 0.11 175);
---brand-primary-light: oklch(0.96 0.04 175);
---brand-teal-hero: oklch(0.20 0.07 175);
---brand-accent: oklch(0.75 0.16 85);
---brand-accent-dark: oklch(0.65 0.16 85);
---brand-heading: oklch(0.13 0.02 240);
---brand-body: oklch(0.42 0.03 240);
---brand-bg-alt: oklch(0.98 0.01 240);
-
-/* Remapear Shadcn para brand */
---primary: var(--brand-primary);
---primary-foreground: oklch(1 0 0);
-```
+**Notas:**
+- `slug` é gerado no server action a partir do `title` (slugify) e garantido único via constraint
+- `thumbnail_url` aceita path do Supabase Storage ou URL externa (YouTube thumbnail como fallback)
+- `updated_at` atualizado via trigger padrão Supabase
+- A coluna `type` (`ao_vivo` | `gravado`) substitui os dois arrays hardcoded atuais da página
 
 ---
 
 ## Decisões de Estado
 
-| Estado | Tipo | Componente | Justificativa |
-|---|---|---|---|
-| testimonials | prop estática | TestimonialsSection | Dados hardcoded no page.tsx — MVP, sem fetch |
-| cursos | prop estática | CursosDestaque | Já é estático — manter |
-| projetos | prop estática | ProjetosSociais | Já é estático — manter |
-| impacto items | prop estática | ImpactoSection | Já é estático — manter |
-
-> Nenhum estado reativo — page.tsx permanece Server Component puro, sem hooks. ✅ ADR-004.
-
----
-
-## ADR Compliance
-
-- [RESPEITADA] ADR-001: App Router — page.tsx Server Component, sem 'use client'
-- [RESPEITADA] ADR-003: Tailwind v4 — tokens via `@theme` em globals.css, sem tailwind.config.js
-- [RESPEITADA] ADR-004: MVVM — sem lógica nos Server Components (dados como props)
-- [RESPEITADA] ADR-005: Type-only — todos os novos types usarão `type`, não `interface`
-- [RESPEITADA] ADR-006: Utils reutilizáveis — sem lógica duplicada
-- [RESPEITADA] ADR-007: cn() obrigatório em todos os className JSX
-- [NÃO APLICÁVEL] ADR-002: Supabase — home pública não tem integração com banco
+| Estado | Tipo | Localização | Justificativa |
+|--------|------|-------------|---------------|
+| Lista de eventos (plataforma pública) | Fetch servidor | `eventos/page.tsx` | RSC busca do Supabase com `createServerClient()` — sem hidratação no cliente |
+| Lista de eventos (CMS) | Fetch servidor | `cms/.../eventos/page.tsx` | Mesmo padrão de `admins/page.tsx` — adminClient, dados como props |
+| Filtros de status/tipo (CMS) | URL search params | `EventosList/view.tsx` | `useSearchParams()` + `router.push()` — state persistido na URL, compartilhável |
+| Formulário (criar/editar) | RHF + Zod | `view.tsx` + `viewModel.tsx` | ADR crítica: proibido `useState` para campos |
+| Action state (criar/editar) | `useActionState` | `viewModel.tsx` | Padrão estabelecido em `NovoAdmin/viewModel.tsx` |
+| Confirmação de exclusão | `useState<boolean>` | `DeleteEventoDialog/view.tsx` | Controla visibilidade do confirm inline — não é campo de form, `useState` permitido |
+| Evento de detalhe (plataforma) | Fetch servidor | `eventos/[slug]/page.tsx` | RSC com `notFound()` se slug inválido |
 
 ---
 
-## Arquivos a Modificar / Criar
+## Contratos dos Componentes Principais
+
+```typescript
+// src/lib/supabase/types.ts — adicionar
+
+type EventType = 'ao_vivo' | 'gravado'
+type EventStatus = 'draft' | 'published' | 'archived'
+
+type Event = {
+  id: string
+  slug: string
+  title: string
+  description: string
+  long_description: string | null
+  type: EventType
+  status: EventStatus
+  scheduled_at: string | null      // ISO string
+  duration_minutes: number | null
+  thumbnail_url: string | null
+  youtube_url: string | null
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+// Props dos componentes de lista pública (substituem os types locais atuais)
+type ProximosEventosProps = {
+  eventos: Event[]
+}
+
+type EventosGravadosProps = {
+  eventos: Event[]
+}
+
+// CMS list view
+type EventosListViewProps = {
+  eventos: Event[]
+}
+
+// Detalhe público
+type EventoDetalheViewProps = {
+  evento: Event
+}
+
+// Formulário (criar e editar compartilham o mesmo schema shape)
+type EventoFormData = {
+  title: string
+  description: string
+  long_description: string
+  type: EventType
+  status: EventStatus
+  scheduled_at: string          // input datetime-local → string ISO no server action
+  duration_minutes: number | ''
+  thumbnail_url: string
+  youtube_url: string
+}
+
+// ActionState (reusar o existente de src/lib/supabase/types.ts)
+// type ActionState = { errors?: Record<string, string[]>; message?: string } | undefined
+```
+
+---
+
+## Server Actions
+
+```typescript
+// cms/.../eventos/novo/_features/NovoEvento/actions.ts
+'use server'
+async function criarEvento(
+  _prevState: ActionState,
+  formData: FormData
+): Promise<ActionState>
+// → valida com eventoSchema, gera slug, insere via adminClient, redirect para /cms/dashboard/eventos
+
+// cms/.../eventos/[id]/_features/EditarEvento/actions.ts
+'use server'
+async function editarEvento(
+  id: string,
+  _prevState: ActionState,
+  formData: FormData
+): Promise<ActionState>
+// → valida com eventoSchema, regenera slug se title mudou, update via adminClient, redirect
+
+async function excluirEvento(id: string): Promise<ActionState>
+// → delete via adminClient, redirect para /cms/dashboard/eventos
+// chamado pelo DeleteEventoDialog com useTransition
+
+// src/utils/slugify.ts — função pura nova
+function slugify(text: string): string
+// → lowercase, remove acentos, troca espaços e especiais por "-"
+// usada em criarEvento e editarEvento
+```
+
+---
+
+## ADRs
+
+### ADR-FE-002: Slug gerado server-side, não pelo usuário
+
+**Contexto:** Eventos têm URL pública `/eventos/[slug]`. O slug precisa ser único e amigável para SEO. Expor um campo `slug` editável no formulário adiciona complexidade de UX (validação de unicidade em tempo real, sanitização) sem benefício claro para o MVP.
+
+**Decisão:** O slug é gerado automaticamente no server action a partir do `title` via `slugify()` em `src/utils/slugify.ts`. Em caso de colisão (slug já existe), o server action acrescenta um sufixo numérico (`-2`, `-3` etc.) antes de inserir.
+
+**Alternativas rejeitadas:**
+- Campo slug editável no form — UX desnecessariamente complexa para MVP
+- UUID como rota pública — péssimo para SEO e legibilidade
+
+**Consequências:**
+- `slugify()` vai em `src/utils/` (ADR-006) — reutilizável entre CMS e testes
+- Se o admin editar o título de um evento já publicado, o slug é regenerado — URLs antigas quebram. Aceitável no MVP; nota para documentar ao produto.
+
+---
+
+### ADR-FE-003: Filtros de lista CMS via URL search params (não useState)
+
+**Contexto:** A listagem de eventos do CMS precisa de filtros por `status` e `type`. Armazenar em `useState` perde o estado no refresh e impede compartilhamento de link com filtro aplicado.
+
+**Decisão:** `EventosList/view.tsx` usa `useSearchParams()` para ler os filtros ativos e `useRouter().push()` (ou `<Link>` com query) para alterá-los. O `page.tsx` lê os `searchParams` e filtra os dados antes de passar como props, ou passa todos os eventos e delega o filtro ao client — preferência: filtro server-side para não expor eventos `draft` desnecessariamente via client.
+
+**Alternativas rejeitadas:**
+- `useState` para filtros — perde estado no refresh, não compartilhável
+- Filtro só client-side — exporia todos os registros ao client, incluindo `draft`
+
+**Consequências:**
+- `page.tsx` recebe `searchParams` como prop (padrão Next.js App Router)
+- Navegação entre filtros não causa loading completo (RSC partial rendering)
+
+---
+
+## Arquivos a Modificar/Criar
 
 ```
 MODIFICAR:
-- src/components/layout/globals.css
-- src/app/(publics)/(home)/page.tsx
-- src/app/(publics)/(home)/_features/home/HeroSection.tsx
-- src/app/(publics)/(home)/_features/home/CursosDestaque.tsx
-- src/app/(publics)/(home)/_features/home/ProjetosSociais.tsx
-- src/app/(publics)/(home)/_features/home/ImpactoSection.tsx
-- src/app/(publics)/(home)/_features/home/ParceirosCTA.tsx
+- src/app/(publics)/eventos/page.tsx
+  → remover arrays hardcoded; buscar eventos do Supabase; passar Event[] para componentes
+- src/app/(publics)/eventos/_features/eventos/ProximosEventos.tsx
+  → trocar type local ProximoEvento por Event de @/lib/supabase/types
+- src/app/(publics)/eventos/_features/eventos/EventosGravados.tsx
+  → trocar type local EventoGravado por Event de @/lib/supabase/types
+- src/lib/supabase/types.ts
+  → adicionar Event, EventType, EventStatus
 
 CRIAR:
-- src/app/(publics)/(home)/_features/home/TestimonialsSection.tsx
+- src/utils/slugify.ts
+- src/app/(publics)/eventos/[slug]/page.tsx
+- src/app/(publics)/eventos/[slug]/_features/EventoDetalhe/view.tsx
+- src/app/(cms)/cms/dashboard/eventos/page.tsx
+- src/app/(cms)/cms/dashboard/eventos/_features/EventosList/view.tsx
+- src/app/(cms)/cms/dashboard/eventos/novo/page.tsx
+- src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/view.tsx
+- src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/viewModel.tsx
+- src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/schema.ts
+- src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/actions.ts
+- src/app/(cms)/cms/dashboard/eventos/[id]/page.tsx
+- src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/view.tsx
+- src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/viewModel.tsx
+- src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/actions.ts
+- src/app/(cms)/cms/dashboard/eventos/[id]/_features/DeleteEventoDialog/view.tsx
 ```
 
 ---
 
-## Pontos de Atenção para o Dev (Rodrigo React)
+## Pontos de Atenção para o Dev
 
-1. **CSS tokens OKLCH:** globals.css usa `oklch()` — todos os tokens novos devem seguir o mesmo formato. Não misturar hex diretamente.
-2. **Tailwind v4 com CSS vars:** para usar as vars como utilities Tailwind, adicionar ao `@theme inline` em globals.css (ex: `--color-brand-primary: var(--brand-primary)`). Se não, usar `bg-[var(--brand-primary)]`.
-3. **TestimonialsSection é estático:** dados mocados no page.tsx com 3 depoimentos placeholder de qualidade realista.
-4. **HeroSection split:** usar `grid grid-cols-1 md:grid-cols-[3fr_2fr] gap-12` — decisão de implementação do Rodrigo, mas o resultado deve ser split em desktop, stack em mobile.
-5. **Avatar initials:** `avatarInitials` é 2 chars (ex: "MS") — não usar `<img>` sem src válido.
-6. **`Button render` prop:** padrão deste projeto é `render={<Link href="..." />}` no Shadcn Button (Next.js 16 — ver CursosDestaque.tsx existente).
-7. **`--primary` remapeado:** verificar que o CMS ainda funciona visualmente após a mudança. O dark teal é mais escuro que o preto padrão — pode afetar sidebar do CMS.
-8. **`npm run build` obrigatório** ao final — zero erros TypeScript.
+1. **`scheduled_at` no formulário:** usar `<input type="datetime-local" />` — o valor retorna string `"2026-05-14T15:00"`. O server action deve converter para ISO completo com timezone antes de inserir: `new Date(value).toISOString()`. Validar que o campo é obrigatório apenas quando `type === 'ao_vivo'` (refinement Zod).
+
+2. **Filtro server-side no CMS:** `page.tsx` de eventos recebe `searchParams: { status?: string; type?: string }` e filtra via `.eq()` no Supabase antes de passar para `EventosListView`. Não passar dados `draft` para o client na plataforma pública.
+
+3. **`excluirEvento` com `useTransition`:** o botão de excluir no `DeleteEventoDialog` deve usar `useTransition` para mostrar estado de loading sem bloquear UI. Padrão: `const [isPending, startTransition] = useTransition()` + `startTransition(() => excluirEvento(id))`.
+
+4. **`generateMetadata` no detalhe público:** `eventos/[slug]/page.tsx` deve exportar `generateMetadata` usando `title` e `description` do evento. Se slug não existe, chamar `notFound()` antes de chegar no render.
+
+5. **`thumbnail_url` nulo:** `ProximosEventos` e `EventosGravados` usam `next/image` — se `thumbnail_url` for `null`, usar imagem placeholder (`/images/event-placeholder.jpg`) para evitar erro de `src` vazio. Adicionar domínios do Supabase Storage em `next.config.ts` (seção `images.remotePatterns`).
+
+6. **Sidebar do CMS:** adicionar item "Eventos" no `SidebarNav.tsx` apontando para `/cms/dashboard/eventos`. Não esquecer o ícone adequado do lucide (`CalendarDays`).
+
+7. **Schema compartilhado entre criar e editar:** `EditarEvento/schema.ts` deve importar e reexportar `eventoSchema` de `novo/_features/NovoEvento/schema.ts` — não duplicar a definição (ADR-006).
+
+8. **`npm run build` obrigatório** ao final de cada subtask — zero erros TypeScript antes de marcar como feito.

--- a/docs/.squads/sessions/portal-nexora/architecture.md.bak3
+++ b/docs/.squads/sessions/portal-nexora/architecture.md.bak3
@@ -1,0 +1,347 @@
+# Decisão Arquitetural: Identidade Visual + Redesign da Home
+
+**Data:** 2026-05-02
+**Agent:** Ana Arquitetura + Úrsula UI
+**Squad:** frontend-001
+
+---
+
+## Entendimento da Task
+
+Redesign completo da home page do Portal Nexora como protótipo de identidade visual.
+Análise de concorrentes (Udemy, Alura, Hotmart) para extrair melhores práticas de UI/UX.
+Foco em posicionamento diferenciado: plataforma educacional de impacto social — nem tão corporativa quanto Udemy, nem tão técnica quanto Alura, mais calorosa que Hotmart.
+
+---
+
+## Análise Competitiva — Insights Extraídos
+
+### Udemy
+- **O que funciona:** Paleta neutra (branco/cinza) com accent vibrante que faz o CTA "saltar". Cards com thumbnail, social proof (N alunos). Navbar com busca proeminente.
+- **O que evitar:** Densidade visual excessiva, sensação de marketplace genérico sem personalidade.
+
+### Alura
+- **O que funciona:** Identidade visual forte (fundo navy escuro + tema "oceânico"). Destaque enorme nos números (2.212 cursos, 120k comunidade). CTAs duplos (explorar + matricular). Seção interativa de carreiras.
+- **O que evitar:** Dark background exige muito cuidado de contraste — peso visual alto.
+
+### Hotmart
+- **O que funciona:** Social proof com números enormes (50B+ em vendas, 4.6★ com 200k avaliações) **acima do fold**. Gradiente energético. CTA repetido estrategicamente. Espaçamento generoso.
+- **O que evitar:** Foco em produtor/vendedor não se aplica ao posicionamento social de NEXORA.
+
+### Síntese — O que NEXORA deve incorporar
+
+| Prática | Origem | Aplicação |
+|---|---|---|
+| Social proof numérico no hero | Hotmart | Stats (+500 alunos, +30 projetos, +15 parceiros) no próprio hero |
+| Accent vibrante em CTAs | Udemy | Amber `#F59E0B` como cor de ação primária |
+| Identidade de cor forte e própria | Alura | Deep Teal como primary — diferente dos 3 concorrentes |
+| Espaçamento generoso entre seções | Hotmart | `py-20` mínimo, `py-28` no hero |
+| Depoimentos com foto + contexto | Alura | Nova seção TestimonialsSection |
+| Hero split-layout | Todos | Texto à esquerda, visual/stats à direita (desktop) |
+
+---
+
+## Sistema de Design — Identidade Visual NEXORA
+
+### ADR-VIS-001: Paleta de Cores da Marca
+
+**Contexto:** `globals.css` atual usa tokens Shadcn padrão (preto/branco), sem identidade de marca. Os componentes usam classes Tailwind hardcoded (`blue-900`, `emerald-500`) sem sistema coeso.
+
+**Decisão:** Definir identidade **Deep Teal + Warm Amber** no `globals.css` via CSS custom properties, remapeando os tokens `--primary` e `--accent` do Shadcn.
+
+**Alternativas rejeitadas:**
+- Manter `blue-900`/`emerald-500` inline — sem coesão, difícil manutenção e sem diferenciação
+- Roxo (Udemy) — já ocupado pelos líderes de mercado
+- Laranja (Hotmart) — transmite venda agressiva, não impacto social
+
+**Paleta definida (valores oklch compatíveis com Tailwind v4):**
+
+```
+NEXORA Brand Colors
+─────────────────────────────────────────────────────────────
+Role              Nome           OKLCH aprox.   Hex equiv.
+─────────────────────────────────────────────────────────────
+--brand-primary   Deep Teal      oklch(0.45 0.12 175)  #0F766E  → confiança+tech+social
+--brand-primary-d Dark Teal      oklch(0.38 0.11 175)  #0D5E57  → hover states
+--brand-primary-l Light Teal     oklch(0.96 0.04 175)  #CCFBF1  → bg suave, badges
+--brand-teal-hero Hero BG Teal   oklch(0.20 0.07 175)  #0D3D37  → hero dark bg
+--brand-accent    Warm Amber     oklch(0.75 0.16 85)   #F59E0B  → CTAs, destaques
+--brand-accent-d  Deep Amber     oklch(0.65 0.16 85)   #D97706  → hover do CTA
+--brand-heading   Slate 900      oklch(0.13 0.02 240)  #0F172A  → headings
+--brand-body      Slate 600      oklch(0.42 0.03 240)  #475569  → body text
+--brand-bg-alt    Slate 50       oklch(0.98 0.01 240)  #F8FAFC  → fundos alternados
+─────────────────────────────────────────────────────────────
+```
+
+**Tokens Shadcn remapeados:**
+```
+--primary              → brand-primary  (teal-700)
+--primary-foreground   → white
+```
+
+**Consequências:**
+✅ Identidade única — Deep Teal não existe nos 3 concorrentes analisados
+✅ Teal = saúde + educação + tecnologia na psicologia das cores
+✅ Amber = calor, acessibilidade, missão social, otimismo
+⚠ `--primary` remapeado afeta todos os componentes Shadcn que usam `bg-primary` — validar CMS após implementação
+
+---
+
+### ADR-VIS-002: Tipografia
+
+**Decisão:** Inter (já carregado pelo sistema/Shadcn) sem adicionar dependência nova.
+
+```
+Display (H1):  Inter Black 900,   48–60px desktop / 36px mobile
+Heading (H2):  Inter Bold 700,    32–36px
+Sub-heading:   Inter SemiBold 600, 20–24px
+Body:          Inter Regular 400,  16px, line-height 1.6
+Small/Caption: Inter Medium 500,   14px
+Badge/Label:   Inter SemiBold 600, 12px, letter-spacing 0.08em, UPPERCASE
+```
+
+---
+
+### ADR-VIS-003: Reestruturação das Seções
+
+**Contexto:** Ordem atual não segue boas práticas de landing page de conversão.
+
+**Mudança de ordem:**
+
+```
+ANTES                    DEPOIS
+──────────────────────   ──────────────────────────────────────
+1. HeroSection           1. HeroSection        (split + stats inline)
+2. CursosDestaque        2. ImpactoSection     (movida para cima — social proof)
+3. ProjetosSociais       3. CursosDestaque     (cards redesenhados)
+4. ImpactoSection        4. ProjetosSociais    (nova paleta)
+5. ParceirosCTA          5. TestimonialsSection (NOVO — depoimentos)
+                         6. ParceirosCTA        (redesign — mais impacto)
+```
+
+**Justificativa:** Social proof deve aparecer antes dos cursos. Depoimentos antes do CTA final é prática universal de alta conversão (validado pelos 3 concorrentes).
+
+---
+
+## Estrutura de Componentes
+
+```
+src/app/(publics)/(home)/
+├── page.tsx                                    ← reordenar + adicionar Testimonials
+└── _features/home/
+    ├── HeroSection.tsx                         ← redesign: split layout, teal dark bg, amber CTA
+    ├── CursosDestaque.tsx                      ← nova paleta, cards sem border-l colorida
+    ├── ProjetosSociais.tsx                     ← nova paleta teal/amber
+    ├── ImpactoSection.tsx                      ← fundo teal-50 (não dark), stats maiores
+    ├── ParceirosCTA.tsx                        ← dark teal bg, amber CTA large
+    └── TestimonialsSection.tsx                 ← NOVO: 3 cards de depoimento
+```
+
+### Novo type (TestimonialsSection)
+
+```typescript
+type Testimonial = {
+  id: string
+  quote: string
+  author: string
+  role: string
+  avatarInitials: string
+}
+```
+
+---
+
+## Especificação Visual por Seção (Úrsula UI)
+
+### 1. HeroSection — Split Layout
+
+**Desktop layout:**
+```
+┌────────────────────────────────────────────────────────────┐
+│  bg: teal-900 (#0D3D37)                py-28               │
+├────────────────────────────┬───────────────────────────────┤
+│ col-span 55%               │ col-span 45%                  │
+│                            │                               │
+│  [PLATAFORMA EDUCACIONAL]  │   [Ilustração / placeholder   │
+│  badge amber-400           │    SVG ou imagem hero]        │
+│                            │                               │
+│  H1: Tecnologia que        │   ┌───────────────────────┐  │
+│  conecta, educa e          │   │  +500    +30    +15   │  │
+│  transforma vidas          │   │ Alunos  Proj.  Parc.  │  │
+│                            │   └───────────────────────┘  │
+│  P: Projetos sociais,      │                               │
+│  cursos profission.        │                               │
+│  e impacto real.           │                               │
+│                            │                               │
+│  [Ver Cursos ▶] [Parceiro] │                               │
+└────────────────────────────┴───────────────────────────────┘
+```
+
+**Estados e especificações:**
+- Background: `bg-[var(--brand-teal-hero)]` ou `bg-teal-900`
+- Badge: `text-amber-400 text-xs font-semibold tracking-widest uppercase`
+- H1: `text-5xl md:text-6xl font-black text-white leading-[1.1]`
+- Subtitle: `text-teal-200 text-lg leading-relaxed`
+- CTA primário: `bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold h-11 px-7 transition-colors`
+- CTA secundário: `border border-teal-600 text-white hover:bg-teal-800 h-11 px-7 transition-colors`
+- Stats — número: `text-amber-400 text-4xl font-black`
+- Stats — label: `text-teal-300 text-xs font-medium`
+- Divisores stats: `border-r border-teal-700`
+- Mobile: single column, visual oculto (`hidden md:block`)
+
+**Acessibilidade:**
+- `aria-labelledby="hero-title"` mantido
+- Contraste H1 (white over teal-900): > 10:1 ✅
+- Contraste amber-400 over teal-900: ~4.7:1 ✅ AA
+
+---
+
+### 2. ImpactoSection — Fundo Claro
+
+**Especificações:**
+- Background: `bg-teal-50` (não dark como antes)
+- Número: `text-6xl font-black text-teal-700`
+- Label: `text-slate-600 text-sm font-medium mt-1`
+- Divisores: `border-r border-teal-200`
+- Padding: `py-16`
+
+---
+
+### 3. CursosDestaque — Cards Redesenhados
+
+**Cards:**
+- Remover `border-l-4 border-l-emerald-500`
+- Adicionar `border border-slate-200 shadow-sm hover:shadow-md hover:-translate-y-1`
+- Tag de categoria: `bg-teal-100 text-teal-700 border-0`
+- Title: `text-slate-900 font-semibold`
+- CTA card: `bg-teal-700 hover:bg-teal-600 text-white w-full` (teal, não emerald)
+- Background seção: `bg-slate-50`
+
+---
+
+### 4. ProjetosSociais — Nova Paleta
+
+- Background: `bg-white`
+- Border card: `border-l-4 border-l-teal-600` (manter padrão lateral, trocar cor)
+- Icon container: `bg-teal-100` → ícone `text-teal-600`
+- Title cards: `text-slate-900`
+
+---
+
+### 5. TestimonialsSection — Novo Componente
+
+**Layout:**
+```
+┌────────────────────────────────────────────────────────────┐
+│  bg-white    "O que nossos alunos dizem"   py-20           │
+│  ┌──────────────────┐ ┌──────────────────┐ ┌─────────────┐│
+│  │ ★★★★★            │ │ ★★★★★            │ │ ★★★★★       ││
+│  │ "Quote do aluno  │ │ "Quote do aluno  │ │ "Quote..."  ││
+│  │  em itálico"     │ │  em itálico"     │ │             ││
+│  │                  │ │                  │ │             ││
+│  │ [AB] Nome        │ │ [CD] Nome        │ │ [EF] Nome   ││
+│  │ Curso cursado    │ │ Curso cursado    │ │ Curso       ││
+│  └──────────────────┘ └──────────────────┘ └─────────────┘│
+└────────────────────────────────────────────────────────────┘
+```
+
+**Especificações:**
+- Background seção: `bg-white`
+- Cards: `bg-slate-50 border border-slate-200 rounded-xl p-6`
+- Stars: `text-amber-400` (5 ícones `Star` do lucide, `fill-amber-400`)
+- Quote: `text-slate-700 italic text-base leading-relaxed`
+- Avatar: `size-10 rounded-full bg-teal-700 text-white flex items-center justify-center text-sm font-bold`
+- Author name: `text-slate-900 font-semibold text-sm`
+- Role: `text-teal-600 text-xs`
+
+**Acessibilidade:**
+- Contraste quote (slate-700 over slate-50): ~6.7:1 ✅ AA
+- Avatar é decorativo — `aria-hidden="true"` no div
+
+---
+
+### 6. ParceirosCTA — Dark e Imponente
+
+**Especificações:**
+- Background: `bg-teal-900` com subtle dot pattern via `bg-[radial-gradient(circle,_rgba(255,255,255,0.05)_1px,_transparent_1px)] [background-size:24px_24px]`
+- Título: `text-white text-4xl font-black`
+- Subtitle: `text-teal-200 text-lg`
+- CTA: `bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold h-14 px-10 text-lg transition-colors`
+- Padding: `py-28`
+
+---
+
+## Tokens CSS a adicionar em globals.css
+
+```css
+/* Adicionar no :root — Brand NEXORA */
+--brand-primary: oklch(0.45 0.12 175);
+--brand-primary-dark: oklch(0.38 0.11 175);
+--brand-primary-light: oklch(0.96 0.04 175);
+--brand-teal-hero: oklch(0.20 0.07 175);
+--brand-accent: oklch(0.75 0.16 85);
+--brand-accent-dark: oklch(0.65 0.16 85);
+--brand-heading: oklch(0.13 0.02 240);
+--brand-body: oklch(0.42 0.03 240);
+--brand-bg-alt: oklch(0.98 0.01 240);
+
+/* Remapear Shadcn para brand */
+--primary: var(--brand-primary);
+--primary-foreground: oklch(1 0 0);
+```
+
+---
+
+## Decisões de Estado
+
+| Estado | Tipo | Componente | Justificativa |
+|---|---|---|---|
+| testimonials | prop estática | TestimonialsSection | Dados hardcoded no page.tsx — MVP, sem fetch |
+| cursos | prop estática | CursosDestaque | Já é estático — manter |
+| projetos | prop estática | ProjetosSociais | Já é estático — manter |
+| impacto items | prop estática | ImpactoSection | Já é estático — manter |
+
+> Nenhum estado reativo — page.tsx permanece Server Component puro, sem hooks. ✅ ADR-004.
+
+---
+
+## ADR Compliance
+
+- [RESPEITADA] ADR-001: App Router — page.tsx Server Component, sem 'use client'
+- [RESPEITADA] ADR-003: Tailwind v4 — tokens via `@theme` em globals.css, sem tailwind.config.js
+- [RESPEITADA] ADR-004: MVVM — sem lógica nos Server Components (dados como props)
+- [RESPEITADA] ADR-005: Type-only — todos os novos types usarão `type`, não `interface`
+- [RESPEITADA] ADR-006: Utils reutilizáveis — sem lógica duplicada
+- [RESPEITADA] ADR-007: cn() obrigatório em todos os className JSX
+- [NÃO APLICÁVEL] ADR-002: Supabase — home pública não tem integração com banco
+
+---
+
+## Arquivos a Modificar / Criar
+
+```
+MODIFICAR:
+- src/components/layout/globals.css
+- src/app/(publics)/(home)/page.tsx
+- src/app/(publics)/(home)/_features/home/HeroSection.tsx
+- src/app/(publics)/(home)/_features/home/CursosDestaque.tsx
+- src/app/(publics)/(home)/_features/home/ProjetosSociais.tsx
+- src/app/(publics)/(home)/_features/home/ImpactoSection.tsx
+- src/app/(publics)/(home)/_features/home/ParceirosCTA.tsx
+
+CRIAR:
+- src/app/(publics)/(home)/_features/home/TestimonialsSection.tsx
+```
+
+---
+
+## Pontos de Atenção para o Dev (Rodrigo React)
+
+1. **CSS tokens OKLCH:** globals.css usa `oklch()` — todos os tokens novos devem seguir o mesmo formato. Não misturar hex diretamente.
+2. **Tailwind v4 com CSS vars:** para usar as vars como utilities Tailwind, adicionar ao `@theme inline` em globals.css (ex: `--color-brand-primary: var(--brand-primary)`). Se não, usar `bg-[var(--brand-primary)]`.
+3. **TestimonialsSection é estático:** dados mocados no page.tsx com 3 depoimentos placeholder de qualidade realista.
+4. **HeroSection split:** usar `grid grid-cols-1 md:grid-cols-[3fr_2fr] gap-12` — decisão de implementação do Rodrigo, mas o resultado deve ser split em desktop, stack em mobile.
+5. **Avatar initials:** `avatarInitials` é 2 chars (ex: "MS") — não usar `<img>` sem src válido.
+6. **`Button render` prop:** padrão deste projeto é `render={<Link href="..." />}` no Shadcn Button (Next.js 16 — ver CursosDestaque.tsx existente).
+7. **`--primary` remapeado:** verificar que o CMS ainda funciona visualmente após a mudança. O dark teal é mais escuro que o preto padrão — pode afetar sidebar do CMS.
+8. **`npm run build` obrigatório** ao final — zero erros TypeScript.

--- a/docs/.squads/sessions/portal-nexora/context.md
+++ b/docs/.squads/sessions/portal-nexora/context.md
@@ -17,6 +17,20 @@ O projeto iniciou com protótipos HTML estáticos. A migração garante que todo
 
 ---
 
+## Sessão 2026-05-06 — Fluxo de Eventos (CMS + Plataforma)
+
+### O que é
+CRUD completo de eventos: cadastro, edição, exclusão e listagem — tanto no CMS (área administrativa) quanto na plataforma pública. Cobre issues #34–40 (feature:eventos).
+
+### Por que existe
+O Portal Nexora realiza eventos presenciais e online (workshops, lives, meetups). A gestão desses eventos precisa de interface administrativa no CMS e de páginas públicas na plataforma para listagem e detalhe.
+
+### Escopo
+- **CMS:** listagem de eventos com filtros, formulário de criação, edição e exclusão (com confirmação)
+- **Plataforma pública:** `/eventos` (listagem) e `/eventos/[slug]` (detalhe) — estas são server pages, sem formulário de inscrição nesta sessão
+
+---
+
 ## Sessão 2026-04-30 — CMS: Cadastro de Administradores
 
 ### O que é

--- a/docs/.squads/sessions/portal-nexora/feature-notes.md
+++ b/docs/.squads/sessions/portal-nexora/feature-notes.md
@@ -38,6 +38,46 @@
 
 ---
 
+# Feature Notes: Fluxo de Eventos (CMS + Plataforma)
+
+**Data:** 2026-05-06
+**Squad:** frontend-001
+
+## O que foi implementado
+
+- Tipos `Event`, `EventType`, `EventStatus` adicionados em `src/lib/supabase/types.ts` — modelo unificado consumido por CMS e plataforma pública
+- CRUD completo de eventos no CMS: listagem com filtros server-side, criação, edição e exclusão (`/cms/dashboard/eventos/*`)
+- Rota pública `/eventos` refatorada de dados hardcoded para Supabase, com componentes `ProximosEventos` e `EventosGravados` adaptados ao tipo unificado
+- Rota pública `/eventos/[slug]` com `generateMetadata`, `notFound()` e view de detalhe do evento
+- Utilitários `slugify()` (`src/utils/slugify.ts`) e `formatDate`/`formatDateLong`/`formatTime` (`src/utils/formatDate.ts`) extraídos como funções puras reutilizáveis
+
+## Decisões técnicas tomadas
+
+- **Schema Zod sem `.transform()`** em `duration_minutes`: conversão string→number feita manualmente na Server Action (`Number(parsed.data.duration_minutes)`) para manter compatibilidade com `useForm<EventoFormData>` (inferência de tipo quebra com transform)
+- **`.url()` do Zod v4 depreciado**: substituído por `z.string().optional()` nos campos de URL; validação HTML5 via `type="url"` no input cuida do lado cliente
+- **`formatDate`/`formatTime` extraídas** durante review (3ª duplicação atingida = BLOCKER ADR-006) — `src/utils/formatDate.ts` é agora o utilitário canônico para datas pt-BR
+- **`DeleteEventoDialog` sem form**: padrão `useTransition` + Server Action chamada diretamente no handler do botão, sem `<form>`
+
+## Pontos de atenção para manutenção futura
+
+1. Páginas públicas `/eventos` e `/eventos/[slug]` usam `createAdminClient()` (service role) em vez de `createClient()` (anon key + RLS) — funcionalmente correto para MVP, mas semanticamente errado; migrar para `createClient()` quando RLS de leitura estiver configurado
+2. `EventoDetalhe/view.tsx` usa classes `prose prose-slate` — verificar se `@tailwindcss/typography` está instalado; se não, remover as classes para evitar estilos órfãos
+3. Slug não é regenerado ao editar título — comportamento esperado para MVP, mas quebra URLs existentes se o admin alterar o título de um evento publicado; implementar redirect ou campo slug editável em iteração futura
+4. `DeleteEventoDialog` usa `window.confirm()` — substituir por dialog Shadcn em iteração futura para manter consistência de UI
+
+## BLOCKERs resolvidos do review
+
+- **[BLOCKER] ADR-006 — 3ª duplicação de `formatDate`/`formatTime`**: funções extraídas para `src/utils/formatDate.ts`; todos os pontos de uso atualizados para importar do utilitário canônico
+
+## SUGGESTIONs pendentes (débito técnico)
+
+1. **(Alta)** Migrar `createAdminClient()` nas rotas públicas para `createClient()` com anon key + RLS configurado no Supabase
+2. **(Média)** Verificar e resolver dependência `@tailwindcss/typography` para as classes `prose` em `EventoDetalhe/view.tsx`
+3. **(Baixa)** Substituir `window.confirm()` no `DeleteEventoDialog` por `<AlertDialog>` do Shadcn
+4. **(Baixa)** Avaliar estratégia de slug imutável vs. redirect ao editar título de evento publicado
+
+---
+
 # Feature Notes — Identidade Visual + Redesign da Home
 
 **Data:** 2026-05-02

--- a/docs/.squads/sessions/portal-nexora/memories.md
+++ b/docs/.squads/sessions/portal-nexora/memories.md
@@ -11,6 +11,9 @@
 <!-- /SUMMARY -->
 
 <!-- RECENTES -->
+## Sessão 2026-05-06
+Task: Fluxo de eventos — CRUD completo (CMS) + listagem/detalhe (plataforma pública). Issues #34–40.
+Issue: #34, #35, #39, #40 (feature:eventos)
 ## [frontend-001 · ana-arquitetura-fe] — 2026-04-30
 
 [DECISÃO CRÍTICA] Padrões aprovados — CMS Criar Admin:
@@ -95,4 +98,13 @@ HeroSection → ImpactoSection → CursosDestaque → ProjetosSociais → Testim
 
 Novo componente: `TestimonialsSection.tsx` — dados estáticos hardcoded em page.tsx (3 depoimentos)
 HeroSection: recebe `stats` como prop — split layout desktop, stack mobile
+## [frontend-001 · ana-arquitetura-fe] — 2026-05-06
+
+[DECISÃO CRÍTICA] Padrões aprovados — Fluxo de Eventos:
+- `src/utils/formatDate.ts` é o utilitário canônico para formatação de datas pt-BR — não duplicar em componentes
+- `slugify()` em `src/utils/slugify.ts` é o padrão para geração de slug server-side (ADR-FE-002)
+- Schema Zod sem `.transform()` para campos numéricos de formulário — converter manualmente na Server Action
+- `.url()` do Zod v4 está depreciado — usar `z.string().optional()` + `type="url"` no input HTML
+- `createAdminClient()` é exclusivo do CMS; páginas públicas devem usar `createClient()` (anon + RLS)
+- Padrão de delete sem form: `useTransition` + Server Action chamada direto no handler
 <!-- /RECENTES -->

--- a/docs/.squads/sessions/portal-nexora/review-notes.md
+++ b/docs/.squads/sessions/portal-nexora/review-notes.md
@@ -256,3 +256,90 @@ O Server Action valida o FormData com Zod antes de qualquer chamada ao banco. Me
 ## Decisão
 
 **Aprovado. Zero BLOCKERs.**
+
+---
+
+# Review Notes — Fluxo de Eventos (CMS + Plataforma)
+
+**Data:** 2026-05-06
+**Reviewer:** Renata Revisão
+
+## Resumo
+- BLOCKERs: 1
+- SUGGESTIONs: 4
+- QUESTIONs: 1
+- PRASEs: 6
+
+## Comentários
+
+---
+
+[BLOCKER] `formatDate` / `formatTime` duplicadas em 3 arquivos — CONFLITO ADR-006
+
+Por que é um problema: `formatDate` aparece em `EventosList/view.tsx:33`, `ProximosEventos.tsx:19` e `EventoDetalhe/view.tsx:12`. `formatTime` aparece em `ProximosEventos.tsx:27` e `EventoDetalhe/view.tsx:20`. ADR-006 exige extração para `src/utils/` após a segunda duplicação (Rule of Three atingido). Qualquer mudança de formatação exige editar 3 arquivos.
+
+Fix sugerido:
+```typescript
+// src/utils/formatDate.ts
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit", month: "2-digit", year: "numeric",
+  })
+}
+export function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("pt-BR", {
+    hour: "2-digit", minute: "2-digit",
+  })
+}
+```
+Importar via `@/utils/formatDate` nos 3 arquivos. `EventoDetalhe/view.tsx` usa `month: "long"` — criar `formatDateLong` ou unificar.
+
+---
+
+[SUGGESTION] Páginas públicas usando `createAdminClient()` (service role)
+
+`eventos/page.tsx` e `eventos/[slug]/page.tsx` públicas usam `createAdminClient()`. Correto é `createClient()` (anon key + RLS) para dados públicos. A policy `events_public_read` já filtra `status = 'published'` — o `.eq("status", "published")` manual ficaria redundante. Service role deve ser reservado ao CMS.
+
+---
+
+[SUGGESTION] `EventoDetalheView` usa classes `prose` — verificar plugin typography
+
+`eventos/[slug]/_features/EventoDetalhe/view.tsx:91` usa `prose prose-slate`. Sem `@tailwindcss/typography` no projeto, as classes são ignoradas silenciosamente. Verificar `package.json`; se ausente, remover as classes `prose`.
+
+---
+
+[SUGGESTION] `slugify.ts` — regex com caracteres Unicode literais
+
+`src/utils/slugify.ts:4` usa `/[̀-ͯ]/g` com chars reais. Substituir por `/[̀-ͯ]/g` para clareza e segurança de encoding.
+
+---
+
+[SUGGESTION] `DeleteEventoDialog` usa `window.confirm()` — acessibilidade limitada
+
+OK para MVP. Para iteração futura: substituir por dialog Shadcn com foco gerenciado.
+
+---
+
+[QUESTION] Slug regenerado ao editar título?
+
+`editarEvento` action não atualiza o slug quando o título muda. A ADR-FE-002 mencionou o risco de URLs quebrarem. Confirmar comportamento esperado: slug imutável após criação, ou regenerar?
+
+---
+
+[PRAISE] `useTransition` para exclusão — padrão correto. UI responsiva durante o request sem bloquear a página.
+
+[PRAISE] `generateMetadata` + `notFound()` nas rotas dinâmicas — zero chance de render com dados `undefined`.
+
+[PRAISE] Filtro server-side no CMS — eventos `draft` nunca chegam ao client bundle.
+
+[PRAISE] Schema compartilhado entre Criar e Editar — `EditarEvento/schema.ts` importa e reexporta sem duplicar.
+
+[PRAISE] Zod refinement condicional para `scheduled_at` — validação robusta server-side para campo obrigatório apenas em `ao_vivo`.
+
+[PRAISE] MVVM consistente em 100% das features novas — `view.tsx` sem lógica, `viewModel.tsx` sem JSX, em todos os formulários.
+
+---
+
+## Decisão
+
+**Requer correção do BLOCKER** — `formatDate`/`formatTime` duplicadas violam ADR-006. Fix simples: `src/utils/formatDate.ts` + importar nos 3 arquivos afetados.

--- a/docs/.squads/sessions/portal-nexora/review-notes.md.bak
+++ b/docs/.squads/sessions/portal-nexora/review-notes.md.bak
@@ -1,0 +1,258 @@
+# Review Notes: portal-nexora
+
+> Notas de revisão de todos os roles. Append-only.
+
+---
+
+# Review Notes — Migração HTML → Next.js App Router
+
+**Data:** 2026-04-25
+**Reviewer:** Renata Revisão
+
+## Resumo
+- BLOCKERs: 1
+- SUGGESTIONs: 3
+- QUESTIONs: 1
+- PRASEs: 3
+
+## Comentários
+
+---
+
+[BLOCKER] `src/app/eventos/page.tsx` — URL duplicada no `eventosGravados`
+
+Por que é um problema: o evento "Desenvolvendo com Segurança" usa `youtubeUrl: "https://www.youtube.com/watch?v=IZyad7yAiOk"`, que é o mesmo link do terceiro evento ("GitHub para portfólio"). O HTML legado mostrava `watch?v=Wwet0QK8yJU` como link da imagem e `watch?v=IZyad7yAiOk` no botão — inconsistência do original. Manter o link errado faz o usuário clicar em outro vídeo.
+
+Fix sugerido:
+```typescript
+// Usar o link correto da imagem do original como youtubeUrl do evento 2
+{
+  id: "desenvolvendo-com-seguranca",
+  title: "Desenvolvendo com Segurança",
+  youtubeUrl: "https://www.youtube.com/watch?v=Wwet0QK8yJU",
+  // ...
+}
+```
+Confirmar com o dono do conteúdo qual é o vídeo correto.
+
+---
+
+[SUGGESTION] `src/components/layout/Header/Header.tsx` — padrão de visibilidade do `<nav>`
+
+O comportamento atual usa `{ hidden: !menuOpen, flex: menuOpen }` combinado com `md:flex` na base. Funciona, mas a intenção fica difícil de ler. Um padrão mais claro e à prova de tailwind-merge:
+
+```tsx
+className={cn(
+  "absolute top-full left-0 right-0 bg-blue-900 flex-col",
+  "md:static md:flex md:flex-row md:items-center",
+  menuOpen ? "flex" : "hidden md:flex",
+)}
+```
+
+Sem objects — mais legível e sem risco de conflito de merge.
+
+---
+
+[SUGGESTION] `src/app/eventos/page.tsx` e `src/app/page.tsx` — dados hardcoded nas páginas
+
+Cursos, projetos, impacto e eventos estão declarados como constantes no corpo do arquivo de página. Quando a quantidade de dados crescer ou vier de Supabase, a refatoração vai ser maior. Considerar mover para um arquivo `data.ts` colocalizado (dentro de `_features/home/` e `_features/eventos/`) já agora, mesmo que os dados ainda sejam estáticos.
+
+Não é blocker — o código funciona — mas sinalizo antes de escalar.
+
+---
+
+[SUGGESTION] `public/images/live_segurança.jpeg` — caractere especial no nome do arquivo
+
+O `ç` no nome pode causar inconsistência em sistemas de arquivos case-sensitive (Linux/Vercel) ou ao fazer encoding da URL. Não é blocker se o arquivo existe e o servidor serve corretamente, mas o ideal é renomear para `live_seguranca.jpeg` para evitar surpresas no deploy.
+
+---
+
+[QUESTION] `src/components/layout/Header/Header.tsx` — botão "Entrar" aponta para `/login`
+
+A rota `/login` ainda não existe no projeto. O link está correto conceitualmente, mas vai retornar 404. Isso é intencional (placeholder para futura implementação) ou deveria ser `href="#"` por ora?
+
+---
+
+[PRAISE] Acessibilidade consistente em todos os componentes
+
+Cada `<section>` tem `aria-labelledby` apontando para o `id` do heading correspondente. Imagens com `alt` descritivo (não apenas `alt=""`). Botões e links com `aria-label` onde o texto visível não é suficiente. Padrão de acessibilidade acima da média para o estágio inicial do projeto.
+
+---
+
+[PRAISE] Empty states implementados em `ProximosEventos` e `EventosGravados`
+
+As seções com listas dinâmicas têm branches explícitos para lista vazia, seguindo o padrão de 4 estados (loading/error/empty/data). Mesmo sendo dados estáticos hoje, a estrutura está pronta para receber async sem refatoração de render.
+
+---
+
+[PRAISE] ADR-007 seguida rigorosamente
+
+`cn()` usado em **todo** `className`, incluindo classes estáticas de componentes simples como `Footer`. Zero bypass com template string ou concatenação direta. Exemplo correto que vai servir de referência para futuros componentes.
+
+---
+
+## Decisão
+
+**Aprovado com ressalvas — requer correção do BLOCKER antes de deploy.**
+
+O BLOCKER (URL duplicada do evento 2) é factual e impacta o usuário. As SUGGESTIONs são melhorias não-bloqueantes. A QUESTION sobre `/login` precisa de decisão do produto.
+
+---
+
+# Review Notes — UI/UX Redesign com Shadcn/UI
+
+**Data:** 2026-04-25
+**Reviewer:** Renata Revisão
+
+## Resumo
+- BLOCKERs: 0
+- SUGGESTIONs: 1
+- QUESTIONs: 0
+- PRASEs: 3
+
+## Comentários
+
+---
+
+[SUGGESTION] `Header.tsx` — padrão `render={<Link />}` em Button é novo no projeto
+
+O padrão `render={<Link href="..." />}` é correto para base-ui (substitui `asChild` do Radix). Funciona, mas é desconhecido para quem não conhece base-ui. Considerar documentar em `docs/_memory/project-learnings.md` para que futuros componentes sigam o mesmo padrão sem descobrir por tentativa.
+
+---
+
+[PRAISE] Sheet substitui o menu CSS hack com acessibilidade real
+
+O Shadcn `Sheet` provê trap de foco, fechamento por ESC, backdrop e aria-modal. A troca elimina todos os problemas de acessibilidade mobile do menu anterior sem adicionar código custom. Decisão arquitetural excelente.
+
+---
+
+[PRAISE] Cards com hover effect em `EventosGravados`
+
+O `group-hover:scale-105` no thumbnail + overlay com `PlayCircle` cria uma experiência visual clara de "clicável" sem JavaScript. Padrão declarativo limpo que funciona sem hidratação client-side.
+
+---
+
+[PRAISE] Footer refatorado para layout responsivo com links
+
+O Footer agora tem descrição da marca, links de navegação e copyright — alinhado com o padrão de produto. O uso de `Separator` do Shadcn para a divider é consistente com o design system.
+
+---
+
+## Decisão
+
+**Aprovado. Zero BLOCKERs.**
+
+O redesign Shadcn está bem executado. A SUGGESTION de documentar o padrão `render` não bloqueia nada.
+
+---
+
+# Review Notes — CMS: Criar Novos Administradores
+
+**Data:** 2026-04-30
+**Reviewer:** Renata Revisão
+
+## Resumo
+- BLOCKERs: 1
+- SUGGESTIONs: 2
+- QUESTIONs: 1
+- PRASEs: 3
+
+## Comentários
+
+---
+
+[BLOCKER] `actions.ts` — usuário auth órfão se inserção de profile falhar
+
+Por que é um problema: `auth.admin.createUser()` é chamado primeiro e tem sucesso. Se o `.insert()` em `admin_profiles` falhar em seguida (constraint, timeout, permissão), o usuário existe em `auth.users` mas sem profile. Na próxima tentativa de login, `dashboard/layout.tsx` recebe `profile: null` — o usuário entra no sistema sem role. Além disso, a mesma conta não pode ser criada novamente pois o e-mail já existe no Auth.
+
+Fix sugerido:
+```typescript
+if (profileError) {
+  // limpar o usuário auth para manter consistência
+  await adminClient.auth.admin.deleteUser(authData.user.id)
+  return { message: 'Erro ao criar administrador. Tente novamente.' }
+}
+```
+
+---
+
+[SUGGESTION] `view.tsx` — `<select>` nativo pode ter background branco em alguns navegadores
+
+`bg-transparent` no `<select>` nativo não é respeitado de forma consistente em todos os browsers (especialmente Safari e Windows). Pode exibir fundo branco dentro de um contexto dark mode. Não é crítico agora (sem dark mode confirmado), mas sinalizo para quando o tema for implementado.
+
+---
+
+[SUGGESTION] `actions.ts` — mensagem de erro genérica do Supabase pode vazar informação
+
+`authError?.message` do Supabase pode retornar strings em inglês como `"User already registered"`. Considerar mapear para mensagens em português antes de retornar:
+```typescript
+const isEmailTaken = authError?.message?.includes('already registered')
+return { message: isEmailTaken ? 'Este e-mail já está em uso.' : 'Erro ao criar conta.' }
+```
+
+---
+
+[QUESTION] `viewModel.tsx` — `router.back()` no cancelar
+
+Se o usuário acessar `/cms/dashboard/admins/novo` diretamente (ex: via bookmark), `router.back()` vai navegar para fora do CMS. Isso é comportamento esperado, ou deveria haver um fallback para `/cms/dashboard`?
+
+---
+
+[PRAISE] Separação view / viewModel executada corretamente pela primeira vez no CMS
+
+Esta é a primeira feature do CMS a usar `viewModel.tsx` separado, seguindo o ADR-004 na íntegra. O `view.tsx` é puro JSX + Shadcn — zero lógica. O `viewModel.tsx` encapsula `useActionState`, `useForm`, `useRouter` e `handleCancel`. Vai servir de referência para refatorar as features existentes (`/cms/register`, `/cms/login`).
+
+---
+
+[PRAISE] `ROLE_OPTIONS as const` + `key={opt.value}` — padrão correto para listas estáticas
+
+Array de opções definido como `as const` fora do componente (não recriado a cada render) com `key` estável usando `opt.value`. Pequeno detalhe, mas revela atenção ao desempenho mesmo em listas pequenas.
+
+---
+
+[PRAISE] `criarAdmin` com validação Zod server-side antes de tocar no Supabase
+
+O Server Action valida o FormData com Zod antes de qualquer chamada ao banco. Mesmo que o cliente quebre a validação (JS desativado, request manual), os dados nunca chegam ao Supabase sem passar pelo schema. Defesa em profundidade aplicada corretamente.
+
+---
+
+## Decisão
+
+**Requer correção do BLOCKER** — usuário auth órfão é um problema de consistência de dados real.
+
+---
+
+# Review Notes — Identidade Visual + Redesign da Home
+
+**Data:** 2026-05-02
+**Reviewer:** Renata Revisão
+
+## Resumo
+- BLOCKERs: 0
+- SUGGESTIONs: 4
+- QUESTIONs: 0
+- PRASEs: 5
+
+## Comentários
+
+[SUGGESTION] `HeroSection.tsx` — SVG placeholder usa hex `#5EEAD4` hardcoded nos atributos SVG. Como é decorativo e `aria-hidden="true"`, não bloqueia. Candidato a `currentColor` em iteração futura.
+
+[SUGGESTION] `page.tsx` — `heroStats` e `impactoItems` duplicam os mesmos valores (500/30/15) em estruturas diferentes. Não é bug, mas é candidato a uma fonte única de dados quando vier de Supabase.
+
+[SUGGESTION] `TestimonialsSection.tsx` — stars usam `key={i}` (índice) em uma lista estática imutável de exatamente 5 elementos. É aceitável aqui pois a lista nunca muda de ordem ou tamanho, mas deveria ter um comentário para evitar confusão em reviews futuros.
+
+[SUGGESTION] `TestimonialsSection.tsx` — `footer` dentro de `blockquote` é válido mas pode ser interpretado como "rodapé de seção" por alguns screen readers. Alternativa semântica mais clara: `figure`/`figcaption`. Não bloqueante.
+
+[PRAISE] `page.tsx` permanece Server Component puro — ADR-004 respeitada impecavelmente mesmo com a adição de 3 novos blocos de dados.
+
+[PRAISE] `TestimonialsSection` usa `<article>` para cada depoimento — semântica HTML5 correta para conteúdo independente e potencialmente sindicável.
+
+[PRAISE] `role="img"` + `aria-label="5 estrelas"` no container das estrelas — tratamento proativo de acessibilidade para ícones que comunicam informação.
+
+[PRAISE] `aria-hidden="true"` consistente em todos os elementos decorativos (SVG hero, avatar initials).
+
+[PRAISE] Build `npm run build` passou limpo — zero erros TypeScript. Requisito mínimo atendido.
+
+## Decisão
+
+**Aprovado. Zero BLOCKERs.**

--- a/docs/.squads/sessions/portal-nexora/state.json
+++ b/docs/.squads/sessions/portal-nexora/state.json
@@ -1,13 +1,13 @@
 {
   "feature": "portal-nexora",
   "created_at": "2026-04-25T00:00:00Z",
-  "updated_at": "2026-05-02T00:05:00Z",
+  "updated_at": "2026-05-06T01:00:00Z",
   "squads": {
     "frontend-001": {
       "domain": "frontend",
       "pipeline": "feature-development",
-      "started_at": "2026-05-02T00:00:00Z",
-      "completed_at": "2026-05-02T00:05:00Z",
+      "started_at": "2026-05-06T00:00:00Z",
+      "completed_at": "2026-05-06T01:00:00Z",
       "status": "completed",
       "completed_steps": ["01-gate-integridade", "02-arquitetura", "03-checkpoint-design", "04-implementacao", "05-review", "06-docs"],
       "current_step": null,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
     "next": "16.2.4",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.74.0",
     "shadcn": "^4.4.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.1"

--- a/src/app/(cms)/cms/dashboard/_features/dashboard/view.tsx
+++ b/src/app/(cms)/cms/dashboard/_features/dashboard/view.tsx
@@ -1,30 +1,74 @@
-import { cn } from '@/lib/utils'
+import { CalendarDays, ShieldCheck, Tv2 } from "lucide-react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
-export function DashboardView() {
+type Props = {
+  totalEventos: number;
+  eventosPublicados: number;
+  totalAdmins: number;
+};
+
+type StatCard = {
+  title: string;
+  value: number;
+  description: string;
+  icon: React.ElementType;
+  href: string;
+};
+
+export function DashboardView({ totalEventos, eventosPublicados, totalAdmins }: Props) {
+  const cards: StatCard[] = [
+    {
+      title: "Total de eventos",
+      value: totalEventos,
+      description: `${eventosPublicados} publicado${eventosPublicados !== 1 ? "s" : ""}`,
+      icon: CalendarDays,
+      href: "/cms/dashboard/eventos",
+    },
+    {
+      title: "Eventos publicados",
+      value: eventosPublicados,
+      description: `de ${totalEventos} cadastrado${totalEventos !== 1 ? "s" : ""}`,
+      icon: Tv2,
+      href: "/cms/dashboard/eventos?status=published",
+    },
+    {
+      title: "Administradores",
+      value: totalAdmins,
+      description: "com acesso ao CMS",
+      icon: ShieldCheck,
+      href: "/cms/dashboard/admins",
+    },
+  ];
+
   return (
-    <div className={cn('space-y-6')}>
+    <div className={cn("space-y-6")}>
       <div>
-        <h2 className={cn('text-2xl font-bold tracking-tight')}>Dashboard</h2>
-        <p className={cn('text-muted-foreground')}>
+        <h1 className={cn("text-2xl font-bold tracking-tight")}>Dashboard</h1>
+        <p className={cn("text-muted-foreground mt-1")}>
           Bem-vindo ao painel de administração do Portal Nexora.
         </p>
       </div>
 
-      <div className={cn('grid gap-4 md:grid-cols-3')}>
-        {(['Cursos', 'Conteúdos', 'Usuários'] as const).map((label) => (
-          <div
-            key={label}
-            className={cn(
-              'rounded-lg border bg-card p-6 text-card-foreground shadow-sm'
-            )}
-          >
-            <p className={cn('text-sm font-medium text-muted-foreground')}>
-              {label}
-            </p>
-            <p className={cn('mt-2 text-3xl font-bold')}>—</p>
-          </div>
+      <div className={cn("grid gap-4 md:grid-cols-3")}>
+        {cards.map(({ title, value, description, icon: Icon, href }) => (
+          <Link key={title} href={href} className={cn("group")}>
+            <Card className={cn("transition-shadow group-hover:shadow-md")}>
+              <CardHeader className={cn("flex flex-row items-center justify-between pb-2")}>
+                <CardTitle className={cn("text-sm font-medium text-muted-foreground")}>
+                  {title}
+                </CardTitle>
+                <Icon className={cn("size-4 text-muted-foreground")} aria-hidden="true" />
+              </CardHeader>
+              <CardContent>
+                <p className={cn("text-3xl font-bold")}>{value}</p>
+                <p className={cn("text-xs text-muted-foreground mt-1")}>{description}</p>
+              </CardContent>
+            </Card>
+          </Link>
         ))}
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/DeleteEventoDialog/view.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/DeleteEventoDialog/view.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { excluirEvento } from "../EditarEvento/actions";
+
+type Props = {
+  eventoId: string;
+  eventoTitle: string;
+};
+
+export function DeleteEventoDialog({ eventoId, eventoTitle }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await excluirEvento(eventoId);
+      if (result?.message) {
+        toast.error(result.message ?? "Erro ao excluir");
+      } else {
+        toast.error("Evento excluído");
+      }
+    });
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button type="button" variant="destructive" size="sm" className={cn("shrink-0")} />
+        }
+      >
+        Excluir evento
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Excluir evento</DialogTitle>
+          <DialogDescription>
+            Tem certeza que deseja excluir{" "}
+            <strong>&ldquo;{eventoTitle}&rdquo;</strong>? Esta ação não pode ser
+            desfeita.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose render={<Button type="button" variant="outline" />}>
+            Cancelar
+          </DialogClose>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isPending}
+            onClick={handleDelete}
+          >
+            {isPending ? "Excluindo…" : "Excluir"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/actions.ts
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/actions.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { ActionState } from "@/lib/supabase/types";
+import { eventoSchema } from "./schema";
+
+export async function editarEvento(
+  id: string,
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const raw = {
+    title: formData.get("title"),
+    description: formData.get("description"),
+    long_description: formData.get("long_description") || undefined,
+    type: formData.get("type"),
+    status: formData.get("status"),
+    scheduled_at: formData.get("scheduled_at") || undefined,
+    duration_minutes: formData.get("duration_minutes") || undefined,
+    youtube_url: formData.get("youtube_url") || undefined,
+  };
+
+  const parsed = eventoSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      errors: parsed.error.flatten((issue) => issue.message)
+        .fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const adminClient = createAdminClient();
+
+  const currentThumbnailUrl = (formData.get("current_thumbnail_url") as string | null) || null;
+  let thumbnail_url: string | null = currentThumbnailUrl;
+
+  const thumbnailFile = formData.get("thumbnail_file") as File | null;
+  if (thumbnailFile && thumbnailFile.size > 0) {
+    const ext = thumbnailFile.name.split(".").pop() ?? "jpg";
+    const path = `eventos/${Date.now()}.${ext}`;
+    const { data: uploadData, error: uploadError } = await adminClient.storage
+      .from("images")
+      .upload(path, thumbnailFile, { upsert: false });
+    if (uploadError) {
+      return { message: "Erro ao fazer upload da thumbnail. Tente novamente." };
+    }
+    const { data: publicData } = adminClient.storage
+      .from("images")
+      .getPublicUrl(uploadData.path);
+    thumbnail_url = publicData.publicUrl;
+  }
+
+  const { error } = await adminClient
+    .from("events")
+    .update({
+      title: parsed.data.title,
+      description: parsed.data.description,
+      long_description: parsed.data.long_description ?? null,
+      type: parsed.data.type,
+      status: parsed.data.status,
+      scheduled_at: parsed.data.scheduled_at ?? null,
+      duration_minutes: parsed.data.duration_minutes ? Number(parsed.data.duration_minutes) : null,
+      thumbnail_url,
+      youtube_url: parsed.data.youtube_url || null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  if (error) {
+    return { message: "Erro ao atualizar evento. Tente novamente." };
+  }
+
+  redirect("/cms/dashboard/eventos");
+}
+
+export async function excluirEvento(id: string): Promise<ActionState> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from("events").delete().eq("id", id);
+
+  if (error) {
+    return { message: "Erro ao excluir evento. Tente novamente." };
+  }
+
+  redirect("/cms/dashboard/eventos");
+}

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/schema.ts
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/schema.ts
@@ -1,0 +1,2 @@
+export type { EventoFormData } from "../../../novo/_features/NovoEvento/schema";
+export { eventoSchema } from "../../../novo/_features/NovoEvento/schema";

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/view.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/view.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { Controller } from "react-hook-form";
+import { ThumbnailUpload } from "@/components/cms/ThumbnailUpload";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { Event } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
+import { DeleteEventoDialog } from "../DeleteEventoDialog/view";
+import { useEditarEventoViewModel } from "./viewModel";
+
+type Props = {
+  evento: Event;
+};
+
+export function EditarEventoView({ evento }: Props) {
+  const { form, formAction, isPending, state, handleCancel } =
+    useEditarEventoViewModel(evento);
+  const {
+    register,
+    watch,
+    control,
+    formState: { errors },
+  } = form;
+
+  const tipo = watch("type");
+
+  return (
+    <div className={cn("mx-auto max-w-2xl py-8 px-4")}>
+      <div className={cn("flex items-start justify-between mb-8")}>
+        <div>
+          <h1 className={cn("text-2xl font-bold tracking-tight mb-1")}>
+            Editar evento
+          </h1>
+          <div className={cn("flex items-center gap-2")}>
+            <span className={cn("text-sm text-muted-foreground")}>Slug:</span>
+            <Badge variant="secondary">
+              <code className={cn("font-mono text-xs")}>{evento.slug}</code>
+            </Badge>
+          </div>
+        </div>
+        <DeleteEventoDialog eventoId={evento.id} eventoTitle={evento.title} />
+      </div>
+
+      <form action={formAction} className={cn("space-y-6")}>
+        {/* Informações básicas */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Informações básicas</CardTitle>
+          </CardHeader>
+          <CardContent className={cn("space-y-4")}>
+            <div className={cn("space-y-1.5")}>
+              <Label htmlFor="title">Título</Label>
+              <Input
+                id="title"
+                type="text"
+                {...register("title")}
+                className={cn({
+                  "border-destructive": errors.title || state?.errors?.title,
+                })}
+              />
+              {(errors.title || state?.errors?.title) && (
+                <p className={cn("text-xs text-destructive")}>
+                  {errors.title?.message ?? state?.errors?.title?.[0]}
+                </p>
+              )}
+            </div>
+
+            <div className={cn("space-y-1.5")}>
+              <Label htmlFor="description">Descrição curta</Label>
+              <Input
+                id="description"
+                type="text"
+                {...register("description")}
+                className={cn({
+                  "border-destructive":
+                    errors.description || state?.errors?.description,
+                })}
+              />
+              {(errors.description || state?.errors?.description) && (
+                <p className={cn("text-xs text-destructive")}>
+                  {errors.description?.message ??
+                    state?.errors?.description?.[0]}
+                </p>
+              )}
+            </div>
+
+            <div className={cn("space-y-1.5")}>
+              <Label htmlFor="long_description">
+                Descrição longa (opcional)
+              </Label>
+              <Textarea
+                id="long_description"
+                rows={4}
+                {...register("long_description")}
+                className={cn({
+                  "border-destructive":
+                    errors.long_description ||
+                    state?.errors?.long_description,
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Configurações */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Configurações</CardTitle>
+          </CardHeader>
+          <CardContent className={cn("space-y-4")}>
+            <div className={cn("grid grid-cols-2 gap-4")}>
+              <div className={cn("space-y-1.5")}>
+                <Label htmlFor="type">Tipo</Label>
+                <Controller
+                  control={control}
+                  name="type"
+                  render={({ field }) => (
+                    <>
+                      <input type="hidden" name="type" value={field.value} />
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger
+                          id="type"
+                          className={cn({
+                            "border-destructive":
+                              errors.type || state?.errors?.type,
+                          })}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="ao_vivo">Ao Vivo</SelectItem>
+                          <SelectItem value="gravado">Gravado</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </>
+                  )}
+                />
+                {(errors.type || state?.errors?.type) && (
+                  <p className={cn("text-xs text-destructive")}>
+                    {errors.type?.message ?? state?.errors?.type?.[0]}
+                  </p>
+                )}
+              </div>
+
+              <div className={cn("space-y-1.5")}>
+                <Label htmlFor="status">Status</Label>
+                <Controller
+                  control={control}
+                  name="status"
+                  render={({ field }) => (
+                    <>
+                      <input type="hidden" name="status" value={field.value} />
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger
+                          id="status"
+                          className={cn({
+                            "border-destructive":
+                              errors.status || state?.errors?.status,
+                          })}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="draft">Rascunho</SelectItem>
+                          <SelectItem value="published">Publicado</SelectItem>
+                          <SelectItem value="archived">Arquivado</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </>
+                  )}
+                />
+              </div>
+            </div>
+
+            {tipo === "ao_vivo" && (
+              <div className={cn("space-y-1.5")}>
+                <Label htmlFor="scheduled_at">Data e hora</Label>
+                <Input
+                  id="scheduled_at"
+                  type="datetime-local"
+                  {...register("scheduled_at")}
+                  className={cn({
+                    "border-destructive":
+                      errors.scheduled_at || state?.errors?.scheduled_at,
+                  })}
+                />
+                {(errors.scheduled_at || state?.errors?.scheduled_at) && (
+                  <p className={cn("text-xs text-destructive")}>
+                    {errors.scheduled_at?.message ??
+                      state?.errors?.scheduled_at?.[0]}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className={cn("space-y-1.5")}>
+              <div className={cn("flex items-center gap-1.5")}>
+                <Label htmlFor="duration_minutes">
+                  Duração (minutos, opcional)
+                </Label>
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    className={cn(
+                      "text-muted-foreground hover:text-foreground text-xs",
+                    )}
+                  >
+                    ⓘ
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Duração estimada em minutos
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <Input
+                id="duration_minutes"
+                type="number"
+                min={1}
+                {...register("duration_minutes")}
+                className={cn({
+                  "border-destructive":
+                    errors.duration_minutes ||
+                    state?.errors?.duration_minutes,
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Mídia */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Mídia</CardTitle>
+          </CardHeader>
+          <CardContent className={cn("space-y-4")}>
+            <div className={cn("space-y-1.5")}>
+              <Label>Thumbnail</Label>
+              <ThumbnailUpload initialUrl={evento.thumbnail_url} />
+            </div>
+
+            <div className={cn("space-y-1.5")}>
+              <div className={cn("flex items-center gap-1.5")}>
+                <Label htmlFor="youtube_url">URL do YouTube (opcional)</Label>
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    className={cn(
+                      "text-muted-foreground hover:text-foreground text-xs",
+                    )}
+                  >
+                    ⓘ
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Aceita links do YouTube Watch, youtu.be e transmissões ao
+                    vivo
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <Input
+                id="youtube_url"
+                type="url"
+                {...register("youtube_url")}
+                className={cn({
+                  "border-destructive":
+                    errors.youtube_url || state?.errors?.youtube_url,
+                })}
+              />
+              {(errors.youtube_url || state?.errors?.youtube_url) && (
+                <p className={cn("text-xs text-destructive")}>
+                  {errors.youtube_url?.message ??
+                    state?.errors?.youtube_url?.[0]}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {state?.message && (
+          <Alert variant="destructive">
+            <AlertDescription>{state.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className={cn("flex gap-3 pt-2")}>
+          <Button type="submit" disabled={isPending} className={cn("flex-1")}>
+            {isPending ? "Salvando…" : "Salvar alterações"}
+          </Button>
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            Cancelar
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/viewModel.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/viewModel.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useActionState } from "react";
+import { type UseFormReturn, useForm } from "react-hook-form";
+import type { ActionState, Event } from "@/lib/supabase/types";
+import { editarEvento } from "./actions";
+import { type EventoFormData, eventoSchema } from "./schema";
+
+type EditarEventoViewModel = {
+  form: UseFormReturn<EventoFormData>;
+  formAction: (payload: FormData) => void;
+  isPending: boolean;
+  state: ActionState;
+  handleCancel: () => void;
+};
+
+export function useEditarEventoViewModel(evento: Event): EditarEventoViewModel {
+  const router = useRouter();
+
+  const editarEventoComId = editarEvento.bind(null, evento.id);
+
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    editarEventoComId,
+    undefined,
+  );
+
+  const form = useForm<EventoFormData>({
+    resolver: zodResolver(eventoSchema),
+    defaultValues: {
+      title: evento.title,
+      description: evento.description,
+      long_description: evento.long_description ?? "",
+      type: evento.type,
+      status: evento.status,
+      scheduled_at: evento.scheduled_at
+        ? new Date(evento.scheduled_at).toISOString().slice(0, 16)
+        : "",
+      duration_minutes: evento.duration_minutes?.toString() ?? "",
+      youtube_url: evento.youtube_url ?? "",
+    },
+  });
+
+  function handleCancel() {
+    router.back();
+  }
+
+  return { form, formAction, isPending, state, handleCancel };
+}

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/page.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { EditarEventoView } from "./_features/EditarEvento/view";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const adminClient = createAdminClient();
+  const { data } = await adminClient
+    .from("events")
+    .select("title")
+    .eq("id", id)
+    .single();
+
+  return {
+    title: data
+      ? `Editar: ${data.title} — NEXORA CMS`
+      : "Editar Evento — NEXORA CMS",
+  };
+}
+
+export default async function EditarEventoPage({ params }: PageProps) {
+  const { id } = await params;
+  const adminClient = createAdminClient();
+
+  const { data } = await adminClient
+    .from("events")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!data) {
+    notFound();
+  }
+
+  return <EditarEventoView evento={data} />;
+}

--- a/src/app/(cms)/cms/dashboard/eventos/_features/EventosList/view.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/_features/EventosList/view.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { PlusIcon, SlidersHorizontal } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { Event, EventStatus, EventType } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
+import { formatDate } from "@/utils/formatDate";
+
+type Props = {
+  eventos: Event[];
+  statusFilter?: string;
+  typeFilter?: string;
+};
+
+const STATUS_LABEL: Record<EventStatus, string> = {
+  draft: "Rascunho",
+  published: "Publicado",
+  archived: "Arquivado",
+};
+
+const STATUS_VARIANT: Record<EventStatus, "default" | "secondary" | "outline"> = {
+  draft: "outline",
+  published: "default",
+  archived: "secondary",
+};
+
+const TYPE_LABEL: Record<EventType, string> = {
+  ao_vivo: "Ao Vivo",
+  gravado: "Gravado",
+};
+
+export function EventosListView({ eventos, statusFilter = "", typeFilter = "" }: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState(statusFilter);
+  const [type, setType] = useState(typeFilter);
+
+  function handleFilter() {
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    if (type) params.set("type", type);
+    router.push(`/cms/dashboard/eventos?${params.toString()}`);
+  }
+
+  function handleReset() {
+    setStatus("");
+    setType("");
+    router.push("/cms/dashboard/eventos");
+  }
+
+  const hasActiveFilters = !!statusFilter || !!typeFilter;
+
+  return (
+    <div className={cn("space-y-6")}>
+      <div className={cn("flex items-center justify-between")}>
+        <div>
+          <h1 className={cn("text-2xl font-bold tracking-tight")}>Eventos</h1>
+          <p className={cn("text-sm text-muted-foreground mt-1")}>
+            {eventos.length} evento{eventos.length !== 1 ? "s" : ""} encontrado{eventos.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <Button render={<Link href="/cms/dashboard/eventos/novo" />}>
+          <PlusIcon />
+          Criar evento
+        </Button>
+      </div>
+
+      <Separator />
+
+      <div className={cn("flex items-end gap-3 flex-wrap")}>
+        <SlidersHorizontal className={cn("size-4 text-muted-foreground mb-2")} aria-hidden="true" />
+
+        <div className={cn("space-y-1")}>
+          <Label htmlFor="filter-status" className={cn("text-xs text-muted-foreground")}>
+            Status
+          </Label>
+          <Select value={status} onValueChange={(v) => setStatus(v ?? "")}>
+            <SelectTrigger id="filter-status" className={cn("w-40")}>
+              <SelectValue placeholder="Todos os status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Todos</SelectItem>
+              <SelectItem value="draft">Rascunho</SelectItem>
+              <SelectItem value="published">Publicado</SelectItem>
+              <SelectItem value="archived">Arquivado</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className={cn("space-y-1")}>
+          <Label htmlFor="filter-type" className={cn("text-xs text-muted-foreground")}>
+            Tipo
+          </Label>
+          <Select value={type} onValueChange={(v) => setType(v ?? "")}>
+            <SelectTrigger id="filter-type" className={cn("w-36")}>
+              <SelectValue placeholder="Todos os tipos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Todos</SelectItem>
+              <SelectItem value="ao_vivo">Ao Vivo</SelectItem>
+              <SelectItem value="gravado">Gravado</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button onClick={handleFilter} size="sm">
+          Filtrar
+        </Button>
+        {hasActiveFilters && (
+          <Button onClick={handleReset} variant="ghost" size="sm">
+            Limpar filtros
+          </Button>
+        )}
+      </div>
+
+      {eventos.length === 0 ? (
+        <div className={cn("rounded-lg border border-dashed p-16 text-center")}>
+          <p className={cn("text-sm font-medium text-muted-foreground")}>Nenhum evento encontrado.</p>
+          <p className={cn("text-xs text-muted-foreground mt-1")}>
+            {hasActiveFilters ? "Tente remover os filtros ou " : ""}
+            <Link href="/cms/dashboard/eventos/novo" className={cn("underline underline-offset-2")}>
+              crie um novo evento
+            </Link>
+            .
+          </p>
+        </div>
+      ) : (
+        <div className={cn("rounded-lg border overflow-hidden")}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Título</TableHead>
+                <TableHead className={cn("hidden sm:table-cell")}>Tipo</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className={cn("hidden md:table-cell")}>Criado em</TableHead>
+                <TableHead className={cn("w-16")} />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {eventos.map((evento) => (
+                <TableRow key={evento.id}>
+                  <TableCell>
+                    <div className={cn("font-medium")}>{evento.title}</div>
+                    <div className={cn("text-xs text-muted-foreground font-mono mt-0.5")}>
+                      /{evento.slug}
+                    </div>
+                  </TableCell>
+                  <TableCell className={cn("hidden sm:table-cell")}>
+                    <Badge variant="outline">{TYPE_LABEL[evento.type]}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={STATUS_VARIANT[evento.status]}>
+                      {STATUS_LABEL[evento.status]}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className={cn("hidden md:table-cell text-muted-foreground text-xs")}>
+                    {formatDate(evento.created_at)}
+                  </TableCell>
+                  <TableCell className={cn("text-right")}>
+                    <Tooltip>
+                      <TooltipTrigger render={<span className={cn("inline-block")} />}>
+                        <Link
+                          href={`/cms/dashboard/eventos/${evento.id}`}
+                          className={cn(
+                            "text-xs font-medium text-primary hover:underline underline-offset-2",
+                          )}
+                        >
+                          Editar
+                        </Link>
+                      </TooltipTrigger>
+                      <TooltipContent>Editar "{evento.title}"</TooltipContent>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/actions.ts
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/actions.ts
@@ -1,0 +1,72 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { ActionState } from "@/lib/supabase/types";
+import { slugify } from "@/utils/slugify";
+import { eventoSchema } from "./schema";
+
+export async function criarEvento(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const raw = {
+    title: formData.get("title"),
+    description: formData.get("description"),
+    long_description: formData.get("long_description") || undefined,
+    type: formData.get("type"),
+    status: formData.get("status"),
+    scheduled_at: formData.get("scheduled_at") || undefined,
+    duration_minutes: formData.get("duration_minutes") || undefined,
+    youtube_url: formData.get("youtube_url") || undefined,
+  };
+
+  const parsed = eventoSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      errors: parsed.error.flatten((issue) => issue.message)
+        .fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const adminClient = createAdminClient();
+
+  let thumbnail_url: string | null = null;
+  const thumbnailFile = formData.get("thumbnail_file") as File | null;
+  if (thumbnailFile && thumbnailFile.size > 0) {
+    const ext = thumbnailFile.name.split(".").pop() ?? "jpg";
+    const path = `eventos/${Date.now()}.${ext}`;
+    const { data: uploadData, error: uploadError } = await adminClient.storage
+      .from("images")
+      .upload(path, thumbnailFile, { upsert: false });
+    if (uploadError) {
+      return { message: "Erro ao fazer upload da thumbnail. Tente novamente." };
+    }
+    const { data: publicData } = adminClient.storage
+      .from("images")
+      .getPublicUrl(uploadData.path);
+    thumbnail_url = publicData.publicUrl;
+  }
+
+  const slug = slugify(parsed.data.title);
+
+  const { error } = await adminClient.from("events").insert({
+    slug,
+    title: parsed.data.title,
+    description: parsed.data.description,
+    long_description: parsed.data.long_description ?? null,
+    type: parsed.data.type,
+    status: parsed.data.status,
+    scheduled_at: parsed.data.scheduled_at ?? null,
+    duration_minutes: parsed.data.duration_minutes ? Number(parsed.data.duration_minutes) : null,
+    thumbnail_url,
+    youtube_url: parsed.data.youtube_url || null,
+  });
+
+  if (error) {
+    return { message: "Erro ao criar evento. Tente novamente." };
+  }
+
+  redirect("/cms/dashboard/eventos");
+}

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/schema.ts
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/schema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const eventoSchema = z
+  .object({
+    title: z.string().min(3, "Título deve ter no mínimo 3 caracteres"),
+    description: z
+      .string()
+      .min(10, "Descrição deve ter no mínimo 10 caracteres"),
+    long_description: z.string().optional(),
+    type: z.enum(["ao_vivo", "gravado"]),
+    status: z.enum(["draft", "published", "archived"]),
+    scheduled_at: z.string().optional(),
+    duration_minutes: z.string().optional(),
+    youtube_url: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.type === "ao_vivo") {
+        return !!data.scheduled_at;
+      }
+      return true;
+    },
+    {
+      message: "Data e hora são obrigatórias para eventos ao vivo",
+      path: ["scheduled_at"],
+    },
+  );
+
+export type EventoFormData = z.infer<typeof eventoSchema>;

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/view.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/view.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { Controller } from "react-hook-form";
+import { ThumbnailUpload } from "@/components/cms/ThumbnailUpload";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useNovoEventoViewModel } from "./viewModel";
+
+export function NovoEventoView() {
+  const { form, formAction, isPending, state, handleCancel } =
+    useNovoEventoViewModel();
+  const {
+    register,
+    watch,
+    control,
+    formState: { errors },
+  } = form;
+
+  const tipo = watch("type");
+
+  return (
+    <div className={cn("mx-auto max-w-2xl py-8 px-4")}>
+      <h1 className={cn("text-2xl font-bold tracking-tight mb-1")}>
+        Novo evento
+      </h1>
+      <p className={cn("text-sm text-muted-foreground mb-8")}>
+        Preencha os dados do evento. O slug será gerado automaticamente a partir
+        do título.
+      </p>
+
+      <form action={formAction} className={cn("space-y-6")}>
+        {/* Informações básicas */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Informações básicas</CardTitle>
+          </CardHeader>
+          <CardContent className={cn("space-y-4")}>
+            <div className={cn("space-y-1.5")}>
+              <Label htmlFor="title">Título</Label>
+              <Input
+                id="title"
+                type="text"
+                placeholder="Ex: Live de Segurança Digital"
+                {...register("title")}
+                className={cn({
+                  "border-destructive": errors.title || state?.errors?.title,
+                })}
+              />
+              {(errors.title || state?.errors?.title) && (
+                <p className={cn("text-xs text-destructive")}>
+                  {errors.title?.message ?? state?.errors?.title?.[0]}
+                </p>
+              )}
+            </div>
+
+            <div className={cn("space-y-1.5")}>
+              <Label htmlFor="description">Descrição curta</Label>
+              <Input
+                id="description"
+                type="text"
+                placeholder="Resumo do evento"
+                {...register("description")}
+                className={cn({
+                  "border-destructive":
+                    errors.description || state?.errors?.description,
+                })}
+              />
+              {(errors.description || state?.errors?.description) && (
+                <p className={cn("text-xs text-destructive")}>
+                  {errors.description?.message ??
+                    state?.errors?.description?.[0]}
+                </p>
+              )}
+            </div>
+
+            <div className={cn("space-y-1.5")}>
+              <Label htmlFor="long_description">
+                Descrição longa (opcional)
+              </Label>
+              <Textarea
+                id="long_description"
+                rows={4}
+                placeholder="Detalhes completos do evento..."
+                {...register("long_description")}
+                className={cn({
+                  "border-destructive":
+                    errors.long_description ||
+                    state?.errors?.long_description,
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Configurações */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Configurações</CardTitle>
+          </CardHeader>
+          <CardContent className={cn("space-y-4")}>
+            <div className={cn("grid grid-cols-2 gap-4")}>
+              <div className={cn("space-y-1.5")}>
+                <Label htmlFor="type">Tipo</Label>
+                <Controller
+                  control={control}
+                  name="type"
+                  render={({ field }) => (
+                    <>
+                      <input type="hidden" name="type" value={field.value} />
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger
+                          id="type"
+                          className={cn({
+                            "border-destructive":
+                              errors.type || state?.errors?.type,
+                          })}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="ao_vivo">Ao Vivo</SelectItem>
+                          <SelectItem value="gravado">Gravado</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </>
+                  )}
+                />
+                {(errors.type || state?.errors?.type) && (
+                  <p className={cn("text-xs text-destructive")}>
+                    {errors.type?.message ?? state?.errors?.type?.[0]}
+                  </p>
+                )}
+              </div>
+
+              <div className={cn("space-y-1.5")}>
+                <Label htmlFor="status">Status</Label>
+                <Controller
+                  control={control}
+                  name="status"
+                  render={({ field }) => (
+                    <>
+                      <input type="hidden" name="status" value={field.value} />
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger
+                          id="status"
+                          className={cn({
+                            "border-destructive":
+                              errors.status || state?.errors?.status,
+                          })}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="draft">Rascunho</SelectItem>
+                          <SelectItem value="published">Publicado</SelectItem>
+                          <SelectItem value="archived">Arquivado</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </>
+                  )}
+                />
+              </div>
+            </div>
+
+            {tipo === "ao_vivo" && (
+              <div className={cn("space-y-1.5")}>
+                <Label htmlFor="scheduled_at">Data e hora</Label>
+                <Input
+                  id="scheduled_at"
+                  type="datetime-local"
+                  {...register("scheduled_at")}
+                  className={cn({
+                    "border-destructive":
+                      errors.scheduled_at || state?.errors?.scheduled_at,
+                  })}
+                />
+                {(errors.scheduled_at || state?.errors?.scheduled_at) && (
+                  <p className={cn("text-xs text-destructive")}>
+                    {errors.scheduled_at?.message ??
+                      state?.errors?.scheduled_at?.[0]}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className={cn("space-y-1.5")}>
+              <div className={cn("flex items-center gap-1.5")}>
+                <Label htmlFor="duration_minutes">
+                  Duração (minutos, opcional)
+                </Label>
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    className={cn(
+                      "text-muted-foreground hover:text-foreground text-xs",
+                    )}
+                  >
+                    ⓘ
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Duração estimada em minutos
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <Input
+                id="duration_minutes"
+                type="number"
+                min={1}
+                placeholder="60"
+                {...register("duration_minutes")}
+                className={cn({
+                  "border-destructive":
+                    errors.duration_minutes ||
+                    state?.errors?.duration_minutes,
+                })}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Mídia */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Mídia</CardTitle>
+          </CardHeader>
+          <CardContent className={cn("space-y-4")}>
+            <div className={cn("space-y-1.5")}>
+              <Label>Thumbnail (opcional)</Label>
+              <ThumbnailUpload />
+            </div>
+
+            <div className={cn("space-y-1.5")}>
+              <div className={cn("flex items-center gap-1.5")}>
+                <Label htmlFor="youtube_url">URL do YouTube (opcional)</Label>
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    className={cn(
+                      "text-muted-foreground hover:text-foreground text-xs",
+                    )}
+                  >
+                    ⓘ
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Aceita links do YouTube Watch, youtu.be e transmissões ao
+                    vivo
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <Input
+                id="youtube_url"
+                type="url"
+                placeholder="https://youtube.com/..."
+                {...register("youtube_url")}
+                className={cn({
+                  "border-destructive":
+                    errors.youtube_url || state?.errors?.youtube_url,
+                })}
+              />
+              {(errors.youtube_url || state?.errors?.youtube_url) && (
+                <p className={cn("text-xs text-destructive")}>
+                  {errors.youtube_url?.message ??
+                    state?.errors?.youtube_url?.[0]}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {state?.message && (
+          <Alert variant="destructive">
+            <AlertDescription>{state.message}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className={cn("flex gap-3 pt-2")}>
+          <Button type="submit" disabled={isPending} className={cn("flex-1")}>
+            {isPending ? "Criando evento…" : "Criar evento"}
+          </Button>
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            Cancelar
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/viewModel.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/viewModel.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useActionState } from "react";
+import { type UseFormReturn, useForm } from "react-hook-form";
+import type { ActionState } from "@/lib/supabase/types";
+import { criarEvento } from "./actions";
+import { type EventoFormData, eventoSchema } from "./schema";
+
+type NovoEventoViewModel = {
+  form: UseFormReturn<EventoFormData>;
+  formAction: (payload: FormData) => void;
+  isPending: boolean;
+  state: ActionState;
+  handleCancel: () => void;
+};
+
+export function useNovoEventoViewModel(): NovoEventoViewModel {
+  const router = useRouter();
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    criarEvento,
+    undefined,
+  );
+
+  const form = useForm<EventoFormData>({
+    resolver: zodResolver(eventoSchema),
+    defaultValues: {
+      title: "",
+      description: "",
+      long_description: "",
+      type: "ao_vivo",
+      status: "draft",
+      scheduled_at: "",
+      youtube_url: "",
+    },
+  });
+
+  function handleCancel() {
+    router.back();
+  }
+
+  return { form, formAction, isPending, state, handleCancel };
+}

--- a/src/app/(cms)/cms/dashboard/eventos/novo/page.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { NovoEventoView } from "./_features/NovoEvento/view";
+
+export const metadata: Metadata = {
+  title: "Novo Evento — NEXORA CMS",
+};
+
+export default function NovoEventoPage() {
+  return <NovoEventoView />;
+}

--- a/src/app/(cms)/cms/dashboard/eventos/page.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Event } from "@/lib/supabase/types";
+import { EventosListView } from "./_features/EventosList/view";
+
+export const metadata: Metadata = {
+  title: "Eventos — NEXORA CMS",
+};
+
+type PageProps = {
+  searchParams: Promise<{ status?: string; type?: string }>;
+};
+
+export default async function EventosPage({ searchParams }: PageProps) {
+  const { status, type } = await searchParams;
+
+  const adminClient = createAdminClient();
+
+  let query = adminClient
+    .from("events")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (status) {
+    query = query.eq("status", status);
+  }
+
+  if (type) {
+    query = query.eq("type", type);
+  }
+
+  const { data } = await query;
+
+  const eventos: Event[] = data ?? [];
+
+  return (
+    <EventosListView
+      eventos={eventos}
+      statusFilter={status ?? ""}
+      typeFilter={type ?? ""}
+    />
+  );
+}

--- a/src/app/(cms)/cms/dashboard/page.tsx
+++ b/src/app/(cms)/cms/dashboard/page.tsx
@@ -1,5 +1,24 @@
-import { DashboardView } from './_features/dashboard/view'
+import { createAdminClient } from "@/lib/supabase/admin";
+import { DashboardView } from "./_features/dashboard/view";
 
-export default function DashboardPage() {
-  return <DashboardView />
+export default async function DashboardPage() {
+  const adminClient = createAdminClient();
+
+  const [{ count: totalEventos }, { count: eventosPublicados }, { count: totalAdmins }] =
+    await Promise.all([
+      adminClient.from("events").select("*", { count: "exact", head: true }),
+      adminClient
+        .from("events")
+        .select("*", { count: "exact", head: true })
+        .eq("status", "published"),
+      adminClient.from("profiles").select("*", { count: "exact", head: true }),
+    ]);
+
+  return (
+    <DashboardView
+      totalEventos={totalEventos ?? 0}
+      eventosPublicados={eventosPublicados ?? 0}
+      totalAdmins={totalAdmins ?? 0}
+    />
+  );
 }

--- a/src/app/(cms)/cms/page.tsx
+++ b/src/app/(cms)/cms/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function CMSIndexPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/cms/login");
+  }
+
+  redirect("/cms/dashboard");
+}

--- a/src/app/(publics)/eventos/[slug]/_features/EventoDetalhe/view.tsx
+++ b/src/app/(publics)/eventos/[slug]/_features/EventoDetalhe/view.tsx
@@ -1,0 +1,164 @@
+import { CalendarDays, Clock, Video } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Event } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
+import { formatDateLong, formatTime } from "@/utils/formatDate";
+
+type OutroEvento = Pick<Event, "id" | "slug" | "title" | "description" | "type" | "scheduled_at" | "thumbnail_url">;
+
+type Props = {
+  evento: Event;
+  outrosEventos: OutroEvento[];
+};
+
+function getYouTubeId(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (u.hostname === "youtu.be") return u.pathname.slice(1).split("?")[0];
+    if (u.hostname.includes("youtube.com")) {
+      if (u.pathname.startsWith("/live/")) return u.pathname.split("/live/")[1].split("?")[0];
+      return u.searchParams.get("v");
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function EventoDetalheView({ evento, outrosEventos }: Props) {
+  const videoId = evento.youtube_url ? getYouTubeId(evento.youtube_url) : null;
+
+  return (
+    <main>
+      <div className={cn("max-w-6xl mx-auto px-6 pt-10")}>
+        <Link
+          href="/eventos"
+          className={cn("text-sm text-teal-700 hover:underline mb-6 inline-block")}
+        >
+          ← Voltar para Eventos
+        </Link>
+      </div>
+
+      <div className={cn("max-w-6xl mx-auto px-6 mb-8")}>
+        {videoId ? (
+          <div className={cn("relative w-full aspect-video rounded-xl overflow-hidden bg-black")}>
+            <iframe
+              src={`https://www.youtube-nocookie.com/embed/${videoId}?rel=0&modestbranding=1`}
+              title={evento.title}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+              className={cn("absolute inset-0 w-full h-full border-0")}
+            />
+          </div>
+        ) : (
+          <div className={cn("relative w-full aspect-video rounded-xl overflow-hidden")}>
+            <Image
+              src={evento.thumbnail_url ?? "/images/event-placeholder.jpg"}
+              alt={evento.title}
+              fill
+              priority
+              className={cn("object-cover")}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className={cn("max-w-6xl mx-auto px-6 pb-12")}>
+        <div className={cn("flex flex-wrap gap-2 mb-4")}>
+          {evento.type === "ao_vivo" ? (
+            <Badge className={cn("bg-amber-500 text-white border-0 gap-1")}>
+              <Video className={cn("size-3")} aria-hidden="true" />
+              Ao Vivo
+            </Badge>
+          ) : (
+            <Badge className={cn("bg-teal-100 text-teal-700 border-0 gap-1")}>
+              <Video className={cn("size-3")} aria-hidden="true" />
+              Gravado
+            </Badge>
+          )}
+
+          {evento.scheduled_at && (
+            <>
+              <Badge variant="outline" className={cn("gap-1")}>
+                <CalendarDays className={cn("size-3")} aria-hidden="true" />
+                {formatDateLong(evento.scheduled_at)}
+              </Badge>
+              <Badge variant="outline" className={cn("gap-1")}>
+                <Clock className={cn("size-3")} aria-hidden="true" />
+                {formatTime(evento.scheduled_at)}
+              </Badge>
+            </>
+          )}
+
+          {evento.duration_minutes && (
+            <Badge variant="outline">{evento.duration_minutes} min</Badge>
+          )}
+        </div>
+
+        <h1 className={cn("text-3xl font-bold text-slate-900 mb-4")}>
+          {evento.title}
+        </h1>
+        <p className={cn("text-lg text-slate-600 mb-6")}>{evento.description}</p>
+
+        {evento.long_description && (
+          <div className={cn("mb-8 text-slate-700 leading-relaxed whitespace-pre-line")}>
+            {evento.long_description}
+          </div>
+        )}
+      </div>
+
+      {outrosEventos.length > 0 && (
+        <div className={cn("max-w-6xl mx-auto px-6 pb-16")}>
+          <h2 className={cn("text-xl font-bold text-slate-900 mb-6")}>Outros eventos</h2>
+          <ul className={cn("grid gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0 m-0")}>
+            {outrosEventos.map((outro) => (
+              <li key={outro.id}>
+                <Link href={`/eventos/${outro.slug}`} className={cn("group block h-full")}>
+                  <Card className={cn("h-full overflow-hidden border-t-4 border-t-teal-600 pt-0 hover:shadow-md hover:-translate-y-1 transition-all duration-300")}>
+                    <div className={cn("relative w-full aspect-video overflow-hidden")}>
+                      <Image
+                        src={outro.thumbnail_url ?? "/images/event-placeholder.jpg"}
+                        alt={outro.title}
+                        fill
+                        className={cn("object-cover group-hover:scale-105 transition-transform duration-300")}
+                      />
+                    </div>
+                    <CardHeader className={cn("pb-2")}>
+                      <div className={cn("flex items-center gap-2 mb-1")}>
+                        <Badge
+                          className={cn(
+                            outro.type === "ao_vivo"
+                              ? "bg-amber-500 text-white border-0 gap-1"
+                              : "bg-teal-100 text-teal-700 border-0 gap-1",
+                          )}
+                        >
+                          <Video className={cn("size-3")} aria-hidden="true" />
+                          {outro.type === "ao_vivo" ? "Ao Vivo" : "Gravado"}
+                        </Badge>
+                        {outro.scheduled_at && (
+                          <Badge variant="outline" className={cn("gap-1 text-xs")}>
+                            <CalendarDays className={cn("size-3")} aria-hidden="true" />
+                            {formatDateLong(outro.scheduled_at)}
+                          </Badge>
+                        )}
+                      </div>
+                      <CardTitle className={cn("text-sm leading-snug text-slate-900")}>
+                        {outro.title}
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className={cn("text-xs text-slate-500 leading-relaxed")}>
+                      {outro.description}
+                    </CardContent>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/app/(publics)/eventos/[slug]/page.tsx
+++ b/src/app/(publics)/eventos/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { EventoDetalheView } from "./_features/EventoDetalhe/view";
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const adminClient = createAdminClient();
+  const { data } = await adminClient
+    .from("events")
+    .select("title, description")
+    .eq("slug", slug)
+    .single();
+
+  if (!data) {
+    return { title: "Evento não encontrado — NEXORA" };
+  }
+
+  return {
+    title: `${data.title} — NEXORA`,
+    description: data.description,
+  };
+}
+
+export default async function EventoSlugPage({ params }: PageProps) {
+  const { slug } = await params;
+  const adminClient = createAdminClient();
+
+  const { data } = await adminClient
+    .from("events")
+    .select("*")
+    .eq("slug", slug)
+    .eq("status", "published")
+    .single();
+
+  if (!data) {
+    notFound();
+  }
+
+  const { data: outros } = await adminClient
+    .from("events")
+    .select("id, slug, title, description, type, scheduled_at, thumbnail_url")
+    .eq("status", "published")
+    .neq("id", data.id)
+    .limit(10);
+
+  const outrosEventos = (outros ?? [])
+    .sort(() => Math.random() - 0.5)
+    .slice(0, 3);
+
+  return <EventoDetalheView evento={data} outrosEventos={outrosEventos} />;
+}

--- a/src/app/(publics)/eventos/_features/eventos/EventosGravados.tsx
+++ b/src/app/(publics)/eventos/_features/eventos/EventosGravados.tsx
@@ -1,108 +1,134 @@
-import { PlayCircle, Video } from "lucide-react"
-import Image from "next/image"
+import { PlayCircle, Video } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Event } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
 
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { cn } from "@/lib/utils"
+type Props = {
+  eventos: Event[];
+};
 
-type EventoGravado = {
-  id: string
-  title: string
-  description: string
-  imageUrl: string
-  imageAlt: string
-  youtubeUrl: string
-}
-
-type EventosGravadosProps = {
-  eventos: EventoGravado[]
-}
-
-export function EventosGravados({ eventos }: EventosGravadosProps) {
+export function EventosGravados({ eventos }: Props) {
   if (eventos.length === 0) {
     return (
-      <section className={cn("py-20 px-6 bg-slate-50")} aria-labelledby="gravados-title">
+      <section
+        className={cn("py-20 px-6 bg-slate-50")}
+        aria-labelledby="gravados-title"
+      >
         <div className={cn("max-w-5xl mx-auto text-center")}>
-          <h2 id="gravados-title" className={cn("text-3xl font-bold text-slate-900 mb-4")}>
+          <h2
+            id="gravados-title"
+            className={cn("text-3xl font-bold text-slate-900 mb-4")}
+          >
             Eventos Gravados
           </h2>
-          <p className={cn("text-slate-500")}>Nenhum evento gravado disponível ainda.</p>
+          <p className={cn("text-slate-500")}>
+            Nenhum evento gravado disponível ainda.
+          </p>
         </div>
       </section>
-    )
+    );
   }
 
   return (
-    <section className={cn("py-20 px-6 bg-slate-50")} aria-labelledby="gravados-title">
+    <section
+      className={cn("py-20 px-6 bg-slate-50")}
+      aria-labelledby="gravados-title"
+    >
       <div className={cn("max-w-5xl mx-auto")}>
         <div className={cn("text-center mb-12")}>
-          <h2 id="gravados-title" className={cn("text-3xl font-bold text-slate-900 mb-3")}>
+          <h2
+            id="gravados-title"
+            className={cn("text-3xl font-bold text-slate-900 mb-3")}
+          >
             Eventos Gravados
           </h2>
           <p className={cn("text-slate-500")}>Assista quando e onde quiser.</p>
         </div>
-        <ul className={cn("grid gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0 m-0")}>
+        <ul
+          className={cn(
+            "grid gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0 m-0",
+          )}
+        >
           {eventos.map((evento) => (
-            <li key={evento.id} className={cn("flex")}>
-              <Card
-                className={cn(
-                  "flex flex-col flex-1 overflow-hidden border-t-4 border-t-teal-600 pt-0",
-                  "hover:shadow-md hover:-translate-y-1 transition-all duration-300 group",
-                )}
-              >
-                <a
-                  href={evento.youtubeUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={`Assistir: ${evento.title}`}
-                  className={cn("relative block overflow-hidden aspect-video")}
+              <li key={evento.id} className={cn("flex")}>
+                <Card
+                  className={cn(
+                    "flex flex-col flex-1 overflow-hidden border-t-4 border-t-teal-600 pt-0",
+                    "hover:shadow-md hover:-translate-y-1 transition-all duration-300 group",
+                  )}
                 >
-                  <Image
-                    src={evento.imageUrl}
-                    alt={evento.imageAlt}
-                    fill
-                    className={cn("object-cover group-hover:scale-105 transition-transform duration-300")}
-                  />
-                  <div
-                    className={cn(
-                      "absolute inset-0 bg-teal-900/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200",
-                    )}
-                    aria-hidden="true"
+                  <Link
+                    href={`/eventos/${evento.slug}`}
+                    aria-label={`Ver detalhes: ${evento.title}`}
+                    className={cn("relative block overflow-hidden aspect-video")}
                   >
-                    <PlayCircle className={cn("size-12 text-white")} />
-                  </div>
-                </a>
-                <CardHeader>
-                  <div className={cn("flex items-center gap-2 mb-1")}>
-                    <Badge className={cn("bg-teal-100 text-teal-700 border-0 gap-1")}>
-                      <Video className={cn("size-3")} aria-hidden="true" />
-                      Gravado
-                    </Badge>
-                  </div>
-                  <CardTitle className={cn("text-slate-900 text-sm leading-snug")}>{evento.title}</CardTitle>
-                </CardHeader>
-                <CardContent className={cn("flex-1 text-xs text-slate-500 leading-relaxed")}>
-                  {evento.description}
-                </CardContent>
-                <CardFooter>
-                  <a
-                    href={evento.youtubeUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                    <Image
+                      src={evento.thumbnail_url ?? "/images/event-placeholder.jpg"}
+                      alt={evento.title}
+                      fill
+                      className={cn(
+                        "object-cover group-hover:scale-105 transition-transform duration-300",
+                      )}
+                    />
+                    <div
+                      className={cn(
+                        "absolute inset-0 bg-teal-900/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200",
+                      )}
+                      aria-hidden="true"
+                    >
+                      <PlayCircle className={cn("size-12 text-white")} />
+                    </div>
+                  </Link>
+                  <CardHeader>
+                    <div className={cn("flex items-center gap-2 mb-1")}>
+                      <Badge
+                        className={cn(
+                          "bg-teal-100 text-teal-700 border-0 gap-1",
+                        )}
+                      >
+                        <Video className={cn("size-3")} aria-hidden="true" />
+                        Gravado
+                      </Badge>
+                    </div>
+                    <CardTitle
+                      className={cn("text-slate-900 text-sm leading-snug")}
+                    >
+                      {evento.title}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent
                     className={cn(
-                      "inline-flex items-center justify-center rounded-lg border border-teal-700 text-teal-700 text-sm font-semibold h-8 gap-1.5 px-3 w-full",
-                      "hover:bg-teal-700 hover:text-white transition-colors",
+                      "flex-1 text-xs text-slate-500 leading-relaxed",
                     )}
                   >
-                    <PlayCircle className={cn("size-3.5")} aria-hidden="true" />
-                    Assistir
-                  </a>
-                </CardFooter>
-              </Card>
-            </li>
+                    {evento.description}
+                  </CardContent>
+                  <CardFooter>
+                    <Link
+                      href={`/eventos/${evento.slug}`}
+                      className={cn(
+                        "inline-flex items-center justify-center rounded-lg border border-teal-700 text-teal-700 text-sm font-semibold h-8 gap-1.5 px-3 w-full",
+                        "hover:bg-teal-700 hover:text-white transition-colors",
+                      )}
+                    >
+                      <PlayCircle className={cn("size-3.5")} aria-hidden="true" />
+                      Assistir
+                    </Link>
+                  </CardFooter>
+                </Card>
+              </li>
           ))}
         </ul>
       </div>
     </section>
-  )
+  );
 }

--- a/src/app/(publics)/eventos/_features/eventos/ProximosEventos.tsx
+++ b/src/app/(publics)/eventos/_features/eventos/ProximosEventos.tsx
@@ -1,49 +1,66 @@
-import { CalendarDays, Clock, Video } from "lucide-react"
-import Image from "next/image"
+import { CalendarDays, Clock, Video } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Event } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
+import { formatDate, formatTime } from "@/utils/formatDate";
 
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { cn } from "@/lib/utils"
+type Props = {
+  eventos: Event[];
+};
 
-type ProximoEvento = {
-  id: string
-  title: string
-  date: string
-  time: string
-  description: string
-  imageUrl: string
-  imageAlt: string
-  youtubeUrl: string
-}
-
-type ProximosEventosProps = {
-  eventos: ProximoEvento[]
-}
-
-export function ProximosEventos({ eventos }: ProximosEventosProps) {
+export function ProximosEventos({ eventos }: Props) {
   if (eventos.length === 0) {
     return (
-      <section className={cn("py-20 px-6 bg-white")} aria-labelledby="proximos-title">
+      <section
+        className={cn("py-20 px-6 bg-white")}
+        aria-labelledby="proximos-title"
+      >
         <div className={cn("max-w-5xl mx-auto text-center")}>
-          <h2 id="proximos-title" className={cn("text-3xl font-bold text-slate-900 mb-4")}>
+          <h2
+            id="proximos-title"
+            className={cn("text-3xl font-bold text-slate-900 mb-4")}
+          >
             Próximos Eventos
           </h2>
-          <p className={cn("text-slate-500")}>Nenhum evento programado no momento. Fique de olho!</p>
+          <p className={cn("text-slate-500")}>
+            Nenhum evento programado no momento. Fique de olho!
+          </p>
         </div>
       </section>
-    )
+    );
   }
 
   return (
-    <section className={cn("py-20 px-6 bg-white")} aria-labelledby="proximos-title">
+    <section
+      className={cn("py-20 px-6 bg-white")}
+      aria-labelledby="proximos-title"
+    >
       <div className={cn("max-w-5xl mx-auto")}>
         <div className={cn("text-center mb-12")}>
-          <h2 id="proximos-title" className={cn("text-3xl font-bold text-slate-900 mb-3")}>
+          <h2
+            id="proximos-title"
+            className={cn("text-3xl font-bold text-slate-900 mb-3")}
+          >
             Próximos Eventos
           </h2>
-          <p className={cn("text-slate-500")}>Inscreva-se e participe ao vivo.</p>
+          <p className={cn("text-slate-500")}>
+            Inscreva-se e participe ao vivo.
+          </p>
         </div>
-        <ul className={cn("grid gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0 m-0")}>
+        <ul
+          className={cn(
+            "grid gap-6 sm:grid-cols-2 lg:grid-cols-3 list-none p-0 m-0",
+          )}
+        >
           {eventos.map((evento) => (
             <li key={evento.id} className={cn("flex")}>
               <Card
@@ -54,8 +71,10 @@ export function ProximosEventos({ eventos }: ProximosEventosProps) {
               >
                 <div className={cn("relative")}>
                   <Image
-                    src={evento.imageUrl}
-                    alt={evento.imageAlt}
+                    src={
+                      evento.thumbnail_url ?? "/images/event-placeholder.jpg"
+                    }
+                    alt={evento.title}
                     width={400}
                     height={220}
                     className={cn("w-full h-48 object-cover")}
@@ -63,36 +82,53 @@ export function ProximosEventos({ eventos }: ProximosEventosProps) {
                 </div>
                 <CardHeader>
                   <div className={cn("flex gap-2 flex-wrap mb-1")}>
-                    <Badge className={cn("bg-teal-100 text-teal-700 border-0 gap-1")}>
-                      <CalendarDays className={cn("size-3")} aria-hidden="true" />
-                      {evento.date}
-                    </Badge>
-                    <Badge variant="outline" className={cn("gap-1")}>
-                      <Clock className={cn("size-3")} aria-hidden="true" />
-                      {evento.time}
-                    </Badge>
-                    <Badge className={cn("bg-amber-500 text-white border-0 gap-1")}>
+                    {evento.scheduled_at && (
+                      <>
+                        <Badge
+                          className={cn(
+                            "bg-teal-100 text-teal-700 border-0 gap-1",
+                          )}
+                        >
+                          <CalendarDays
+                            className={cn("size-3")}
+                            aria-hidden="true"
+                          />
+                          {formatDate(evento.scheduled_at)}
+                        </Badge>
+                        <Badge variant="outline" className={cn("gap-1")}>
+                          <Clock className={cn("size-3")} aria-hidden="true" />
+                          {formatTime(evento.scheduled_at)}
+                        </Badge>
+                      </>
+                    )}
+                    <Badge
+                      className={cn("bg-amber-500 text-white border-0 gap-1")}
+                    >
                       <Video className={cn("size-3")} aria-hidden="true" />
                       Ao Vivo
                     </Badge>
                   </div>
-                  <CardTitle className={cn("text-slate-900 text-base")}>{evento.title}</CardTitle>
+                  <CardTitle className={cn("text-slate-900 text-base")}>
+                    {evento.title}
+                  </CardTitle>
                 </CardHeader>
-                <CardContent className={cn("flex-1 text-sm text-slate-600 leading-relaxed")}>
+                <CardContent
+                  className={cn(
+                    "flex-1 text-sm text-slate-600 leading-relaxed",
+                  )}
+                >
                   {evento.description}
                 </CardContent>
                 <CardFooter>
-                  <a
-                    href={evento.youtubeUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <Link
+                    href={`/eventos/${evento.slug}`}
                     className={cn(
                       "inline-flex items-center justify-center rounded-lg bg-amber-500 text-teal-900 text-sm font-bold h-8 gap-1.5 px-3 w-full",
                       "hover:bg-amber-400 transition-colors",
                     )}
                   >
-                    Participar ao Vivo
-                  </a>
+                    {evento.youtube_url ? "Participar ao Vivo" : "Saiba mais"}
+                  </Link>
                 </CardFooter>
               </Card>
             </li>
@@ -100,5 +136,5 @@ export function ProximosEventos({ eventos }: ProximosEventosProps) {
         </ul>
       </div>
     </section>
-  )
+  );
 }

--- a/src/app/(publics)/eventos/page.tsx
+++ b/src/app/(publics)/eventos/page.tsx
@@ -1,61 +1,33 @@
-import { EventosGravados } from "./_features/eventos/EventosGravados"
-import { HeroEventos } from "./_features/eventos/HeroEventos"
-import { ProximosEventos } from "./_features/eventos/ProximosEventos"
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Event } from "@/lib/supabase/types";
+import { EventosGravados } from "./_features/eventos/EventosGravados";
+import { HeroEventos } from "./_features/eventos/HeroEventos";
+import { ProximosEventos } from "./_features/eventos/ProximosEventos";
 
-const proximosEventos = [
-  {
-    id: "live-seguranca-digital",
-    title: "Live: Segurança Digital",
-    date: "14/03/2026",
-    time: "15:00",
-    description: "Dicas importantes para proteger seus dados e navegar com segurança na internet.",
-    imageUrl: "/images/live_segurança.jpeg",
-    imageAlt: "Live Segurança Digital",
-    youtubeUrl: "https://www.youtube.com/@SupimpaTI",
-  },
-]
+export default async function EventosPage() {
+  const adminClient = createAdminClient();
 
-const eventosGravados = [
-  {
-    id: "ciencia-dados-ml",
-    title: "Ciência de Dados e Machine Learning",
-    description: "A importância da análise de dados.",
-    imageUrl: "/images/PALESTRA1.jpg",
-    imageAlt: "Palestra sobre Ciência de Dados",
-    youtubeUrl: "https://www.youtube.com/watch?v=ubbj7slAlGM&t=12s",
-  },
-  {
-    id: "desenvolvendo-com-seguranca",
-    title: "Desenvolvendo com Segurança",
-    description: "Princípios de Cyber Segurança para Devs.",
-    imageUrl: "/images/PALESTRA2.jpeg",
-    imageAlt: "Palestra sobre Desenvolvimento Seguro",
-    youtubeUrl: "https://www.youtube.com/watch?v=Wwet0QK8yJU",
-  },
-  {
-    id: "github-portfolio",
-    title: "Como utilizar o Github para alavancar seu portfólio",
-    description: "Aprenda como utilizar o GitHub para destacar seus projetos.",
-    imageUrl: "/images/PALESTRA3.jpg",
-    imageAlt: "Palestra sobre GitHub para portfólio",
-    youtubeUrl: "https://www.youtube.com/watch?v=IZyad7yAiOk",
-  },
-  {
-    id: "elas-na-robotica",
-    title: "Elas na Robótica",
-    description: "Evento sobre participação feminina na área de tecnologia e robótica.",
-    imageUrl: "/images/PALESTRA4.png",
-    imageAlt: "Evento Elas na Robótica",
-    youtubeUrl: "https://www.youtube.com/watch?v=o0fsnAeaDyQ",
-  },
-]
+  const { data } = await adminClient
+    .from("events")
+    .select("*")
+    .eq("status", "published")
+    .order("created_at", { ascending: false });
 
-export default function EventosPage() {
+  const eventos: Event[] = data ?? [];
+  const now = new Date();
+
+  const proximos = eventos.filter(
+    (e) => e.type === "ao_vivo" && (!e.scheduled_at || new Date(e.scheduled_at) >= now),
+  );
+  const gravados = eventos.filter(
+    (e) => e.type === "gravado" || (e.type === "ao_vivo" && !!e.scheduled_at && new Date(e.scheduled_at) < now),
+  );
+
   return (
     <main>
       <HeroEventos />
-      <ProximosEventos eventos={proximosEventos} />
-      <EventosGravados eventos={eventosGravados} />
+      <ProximosEventos eventos={proximos} />
+      <EventosGravados eventos={gravados} />
     </main>
-  )
+  );
 }

--- a/src/components/cms/CMSShell.tsx
+++ b/src/components/cms/CMSShell.tsx
@@ -1,3 +1,5 @@
+import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { SessionUser } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import { Sidebar } from "./Sidebar";
@@ -10,14 +12,17 @@ type Props = {
 
 export function CMSShell({ user, children }: Props) {
   return (
-    <div className={cn("flex h-screen overflow-hidden")}>
-      <Sidebar user={user} className={cn("sticky top-0 h-screen")} />
+    <TooltipProvider>
+      <div className={cn("flex h-screen overflow-hidden")}>
+        <Sidebar user={user} className={cn("sticky top-0 h-screen")} />
 
-      <div className={cn("flex flex-1 flex-col overflow-hidden")}>
-        <TopBar />
+        <div className={cn("flex flex-1 flex-col overflow-hidden")}>
+          <TopBar />
 
-        <main className={cn("flex-1 overflow-y-auto p-6")}>{children}</main>
+          <main className={cn("flex-1 overflow-y-auto p-6")}>{children}</main>
+        </div>
       </div>
-    </div>
+      <Toaster richColors closeButton />
+    </TooltipProvider>
   );
 }

--- a/src/components/cms/Sidebar/SidebarNav.tsx
+++ b/src/components/cms/Sidebar/SidebarNav.tsx
@@ -1,15 +1,37 @@
 "use client";
 
-import { BookOpen, FileText, LayoutDashboard, ShieldCheck } from "lucide-react";
+import {
+  BookOpen,
+  CalendarDays,
+  FileText,
+  LayoutDashboard,
+  ShieldCheck,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
-  { label: "Dashboard", href: "/cms/dashboard", icon: LayoutDashboard, exact: true },
+  {
+    label: "Dashboard",
+    href: "/cms/dashboard",
+    icon: LayoutDashboard,
+    exact: true,
+  },
   { label: "Conteúdos", href: "/cms/contents", icon: FileText, exact: false },
   { label: "Cursos", href: "/cms/courses", icon: BookOpen, exact: false },
-  { label: "Administradores", href: "/cms/dashboard/admins", icon: ShieldCheck, exact: false },
+  {
+    label: "Administradores",
+    href: "/cms/dashboard/admins",
+    icon: ShieldCheck,
+    exact: false,
+  },
+  {
+    label: "Eventos",
+    href: "/cms/dashboard/eventos",
+    icon: CalendarDays,
+    exact: false,
+  },
 ];
 
 export function SidebarNav() {

--- a/src/components/cms/ThumbnailUpload.tsx
+++ b/src/components/cms/ThumbnailUpload.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { ImageIcon, Upload, X } from "lucide-react";
+import Image from "next/image";
+import { useCallback, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  initialUrl?: string | null;
+  name?: string;
+  currentUrlName?: string;
+};
+
+export function ThumbnailUpload({
+  initialUrl,
+  name = "thumbnail_file",
+  currentUrlName = "current_thumbnail_url",
+}: Props) {
+  const [preview, setPreview] = useState<string | null>(initialUrl ?? null);
+  const [currentUrl, setCurrentUrl] = useState<string>(initialUrl ?? "");
+  const [isDragging, setIsDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback((file: File) => {
+    if (!file.type.startsWith("image/")) return;
+
+    const objectUrl = URL.createObjectURL(file);
+    setPreview(objectUrl);
+
+    const img = new window.Image();
+    img.onload = () => {
+      const MAX = 1080;
+      const scale = Math.min(1, MAX / Math.max(img.width, img.height));
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.round(img.width * scale);
+      canvas.height = Math.round(img.height * scale);
+      canvas.getContext("2d")?.drawImage(img, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(
+        (blob) => {
+          if (!blob || !inputRef.current) return;
+          const webp = new File([blob], "thumbnail.webp", { type: "image/webp" });
+          const dt = new DataTransfer();
+          dt.items.add(webp);
+          inputRef.current.files = dt.files;
+        },
+        "image/webp",
+        0.85,
+      );
+    };
+    img.src = objectUrl;
+  }, []);
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  }
+
+  function handleRemove(e: React.MouseEvent) {
+    e.stopPropagation();
+    setPreview(null);
+    setCurrentUrl("");
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(true);
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  }
+
+  function handleClick() {
+    inputRef.current?.click();
+  }
+
+  return (
+    <div className={cn("w-full")}>
+      <input
+        ref={inputRef}
+        type="file"
+        name={name}
+        accept="image/*"
+        className={cn("hidden")}
+        onChange={handleInputChange}
+      />
+      <input type="hidden" name={currentUrlName} value={currentUrl} />
+
+      {preview ? (
+        <div className={cn("relative w-full rounded-lg overflow-hidden border border-border group")}>
+          <div className={cn("relative w-full aspect-video")}>
+            <Image
+              src={preview}
+              alt="Thumbnail"
+              fill
+              className={cn("object-cover")}
+            />
+          </div>
+          <div
+            className={cn(
+              "absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center gap-3",
+            )}
+          >
+            <button
+              type="button"
+              onClick={handleClick}
+              className={cn(
+                "opacity-0 group-hover:opacity-100 transition-opacity",
+                "inline-flex items-center gap-1.5 rounded-md bg-white/90 text-foreground text-xs font-medium px-3 py-1.5",
+                "hover:bg-white",
+              )}
+            >
+              <Upload className={cn("size-3.5")} aria-hidden="true" />
+              Trocar imagem
+            </button>
+            <button
+              type="button"
+              onClick={handleRemove}
+              aria-label="Remover thumbnail"
+              className={cn(
+                "opacity-0 group-hover:opacity-100 transition-opacity",
+                "inline-flex items-center gap-1.5 rounded-md bg-destructive/90 text-white text-xs font-medium px-3 py-1.5",
+                "hover:bg-destructive",
+              )}
+            >
+              <X className={cn("size-3.5")} aria-hidden="true" />
+              Remover
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={handleClick}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className={cn(
+            "w-full flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed py-10 px-6 transition-colors",
+            isDragging
+              ? "border-primary bg-primary/5"
+              : "border-border hover:border-primary/50 hover:bg-muted/40",
+          )}
+        >
+          <div
+            className={cn(
+              "flex size-10 items-center justify-center rounded-full",
+              isDragging ? "bg-primary/10" : "bg-muted",
+            )}
+          >
+            <ImageIcon
+              className={cn("size-5", isDragging ? "text-primary" : "text-muted-foreground")}
+              aria-hidden="true"
+            />
+          </div>
+          <div className={cn("text-center")}>
+            <p className={cn("text-sm font-medium text-foreground")}>
+              Arraste e solte ou{" "}
+              <span className={cn("text-primary underline-offset-2 hover:underline")}>
+                clique para selecionar
+              </span>
+            </p>
+            <p className={cn("text-xs text-muted-foreground mt-1")}>
+              PNG, JPG, WebP — máx. 5 MB
+            </p>
+          </div>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,7 +21,7 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-9 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left w-full", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex items-center w-full justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,23 +1,53 @@
-type AdminRole = 'admin' | 'content_creator' | 'professor'
+type AdminRole = "admin" | "content_creator" | "professor";
 
 type AdminProfile = {
-  id: string
-  user_id: string
-  full_name: string
-  role: AdminRole
-  avatar_url: string | null
-  created_at: string
-}
+  id: string;
+  user_id: string;
+  full_name: string;
+  role: AdminRole;
+  avatar_url: string | null;
+  created_at: string;
+};
 
 type SessionUser = {
-  id: string
-  email: string
-  profile: AdminProfile
-}
+  id: string;
+  email: string;
+  profile: AdminProfile;
+};
 
-type ActionState = {
-  errors?: Record<string, string[]>
-  message?: string
-} | undefined
+type ActionState =
+  | {
+      errors?: Record<string, string[]>;
+      message?: string;
+    }
+  | undefined;
 
-export type { AdminRole, AdminProfile, SessionUser, ActionState }
+type EventType = "ao_vivo" | "gravado";
+type EventStatus = "draft" | "published" | "archived";
+
+type Event = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  long_description: string | null;
+  type: EventType;
+  status: EventStatus;
+  scheduled_at: string | null;
+  duration_minutes: number | null;
+  thumbnail_url: string | null;
+  youtube_url: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type {
+  AdminRole,
+  AdminProfile,
+  SessionUser,
+  ActionState,
+  EventType,
+  EventStatus,
+  Event,
+};

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,22 @@
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  })
+}
+
+export function formatDateLong(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  })
+}
+
+export function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,10 @@
+export function slugify(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,13 @@
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
   integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
+"@hookform/resolvers@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.2.2.tgz#5ac16cd89501ca31671e6e9f0f5c5d762a99aa12"
+  integrity sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@img/colour@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz#b0c2c2fa661adf75effd6b4964497cd80010bb9d"
@@ -777,6 +784,73 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
   integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
 
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
+
+"@supabase/auth-js@2.105.3":
+  version "2.105.3"
+  resolved "https://registry.yarnpkg.com/@supabase/auth-js/-/auth-js-2.105.3.tgz#a9ff10797ab218663125a939c3dbf4eae7409dfd"
+  integrity sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/functions-js@2.105.3":
+  version "2.105.3"
+  resolved "https://registry.yarnpkg.com/@supabase/functions-js/-/functions-js-2.105.3.tgz#5673be3b258bd19c32f919294213b0964b3cfd44"
+  integrity sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/phoenix@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@supabase/phoenix/-/phoenix-0.4.1.tgz#b851f5c6d0b588f624f185d78ddddfa2ce57dd82"
+  integrity sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==
+
+"@supabase/postgrest-js@2.105.3":
+  version "2.105.3"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz#84ffb6fb4dced9b49e8246f4fd8b76a4f765b9f6"
+  integrity sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==
+  dependencies:
+    tslib "2.8.1"
+
+"@supabase/realtime-js@2.105.3":
+  version "2.105.3"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-2.105.3.tgz#ba4702d5bb94d0aed2da884cf63a6a6cfbdba2f1"
+  integrity sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==
+  dependencies:
+    "@supabase/phoenix" "^0.4.1"
+    "@types/ws" "^8.18.1"
+    tslib "2.8.1"
+    ws "^8.18.2"
+
+"@supabase/ssr@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@supabase/ssr/-/ssr-0.10.2.tgz#55f4675eef530eaee4a2c9c5ec6a6f01802fe1f7"
+  integrity sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==
+  dependencies:
+    cookie "^1.0.2"
+
+"@supabase/storage-js@2.105.3":
+  version "2.105.3"
+  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-2.105.3.tgz#ca4097d41555118d8dc76943efb7e09c24df50bf"
+  integrity sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==
+  dependencies:
+    iceberg-js "^0.8.1"
+    tslib "2.8.1"
+
+"@supabase/supabase-js@^2.105.1":
+  version "2.105.3"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-2.105.3.tgz#831c4b273490ed169c22c99f64e63d8c53bb0c21"
+  integrity sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==
+  dependencies:
+    "@supabase/auth-js" "2.105.3"
+    "@supabase/functions-js" "2.105.3"
+    "@supabase/postgrest-js" "2.105.3"
+    "@supabase/realtime-js" "2.105.3"
+    "@supabase/storage-js" "2.105.3"
+
 "@swc/helpers@0.5.15":
   version "0.5.15"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
@@ -951,6 +1025,13 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz#df0f7dac25df7761f7476605ddac54cb1abda26e"
   integrity sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==
+
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 accepts@^2.0.0:
   version "2.0.0"
@@ -1206,7 +1287,7 @@ cookie@^0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-cookie@^1.1.1:
+cookie@^1.0.2, cookie@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
@@ -1750,6 +1831,11 @@ human-signals@^8.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-8.0.1.tgz#f08bb593b6d1db353933d06156cedec90abe51fb"
   integrity sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==
 
+iceberg-js@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/iceberg-js/-/iceberg-js-0.8.1.tgz#47d893468293a010385e1c70123f29d0fc1d9912"
+  integrity sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==
+
 iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
@@ -2179,6 +2265,11 @@ negotiator@^1.0.0:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
+next-themes@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.4.6.tgz#8d7e92d03b8fea6582892a50a928c9b23502e8b6"
+  integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
+
 next@16.2.4:
   version "16.2.4"
   resolved "https://registry.yarnpkg.com/next/-/next-16.2.4.tgz#b1f708a283052e8ccb86ef16001d69e558e6ef5f"
@@ -2470,6 +2561,11 @@ react-dom@19.2.4:
   dependencies:
     scheduler "^0.27.0"
 
+react-hook-form@^7.74.0:
+  version "7.75.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.75.0.tgz#4364affb4af39e45eeb7e3c6e10f6579cdcca7a2"
+  integrity sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==
+
 react@19.2.4:
   version "19.2.4"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
@@ -2745,6 +2841,11 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
+
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -2906,7 +3007,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.1, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
+tslib@2.8.1, tslib@^2.0.1, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -3028,6 +3129,11 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+ws@^8.18.2:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
+  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+
 wsl-utils@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/wsl-utils/-/wsl-utils-0.3.1.tgz#9479836ddf03be267aad3abfc3cb1f6e0c9f1ed1"
@@ -3090,3 +3196,8 @@ zod@^3.24.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
+zod@^4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

- **CMS CRUD de eventos** — listagem com filtros, criar, editar, excluir com Dialog de confirmação
- **Upload de thumbnail** com compressão WebP client-side (Canvas API) + Supabase Storage
- **Plataforma pública** — `/eventos` conectado ao Supabase, `/eventos/[slug]` com player YouTube embedado (sem sair do portal)
- **Shadcn UI expandido** — Select, Textarea, Dialog, Table, Alert, Tooltip, Skeleton, Sonner instalados e aplicados
- **Dashboard** com contadores reais de eventos e administradores
- **Redirect `/cms`** → `/cms/login` ou `/cms/dashboard` conforme sessão

## Mudanças principais

### Novos arquivos
- `src/app/(cms)/cms/dashboard/eventos/**` — CRUD completo (listagem, criar, editar, excluir)
- `src/app/(cms)/cms/page.tsx` — redirect inteligente baseado em sessão
- `src/app/(publics)/eventos/[slug]/**` — página de detalhe com player YouTube
- `src/components/cms/ThumbnailUpload.tsx` — drag-and-drop + compressão WebP
- `src/utils/slugify.ts` / `src/utils/formatDate.ts` — utilitários canônicos
- `src/components/ui/{select,textarea,dialog,table,alert,tooltip,skeleton,sonner}.tsx`

### Arquivos modificados
- `src/app/(publics)/eventos/page.tsx` — dados do Supabase em vez de hardcoded
- `src/app/(publics)/eventos/_features/eventos/{ProximosEventos,EventosGravados}.tsx` — cards linkam para página interna
- `src/components/cms/{CMSShell,Sidebar/SidebarNav}.tsx` — TooltipProvider, Toaster, item Eventos
- `src/lib/supabase/types.ts` — `Event`, `EventType`, `EventStatus`
- `next.config.ts` — `remotePatterns` para `*.supabase.co`

## Test plan

- [ ] Criar evento via CMS com thumbnail e verificar upload no bucket `images`
- [ ] Editar evento e confirmar que thumbnail existente é preservada se nenhum novo arquivo for selecionado
- [ ] Excluir evento e confirmar Dialog + toast de confirmação
- [ ] Filtros de status/tipo na listagem CMS
- [ ] `/eventos` público exibe eventos do Supabase
- [ ] `/eventos/[slug]` renderiza player YouTube inline
- [ ] Evento ao vivo com data passada aparece em "Eventos Gravados"
- [ ] `/cms` sem sessão → redirect `/cms/login`; com sessão → `/cms/dashboard`
- [ ] Dashboard mostra contadores reais

🤖 Generated with [Claude Code](https://claude.com/claude-code)