### PR TITLE
fix: eventos CMS não refletiam na página pública

### DIFF
--- a/.synapos/squads/frontend-001/squad.yaml
+++ b/.synapos/squads/frontend-001/squad.yaml
@@ -6,8 +6,9 @@ status: active
 mode: economico
 execution_mode: complete
 created_at: 2026-05-02
-feature: portal-nexora
-session: docs/.squads/sessions/portal-nexora
+updated_at: 2026-05-08
+feature: fix-update-fluxo-criar-eventos
+session: docs/.squads/sessions/fix-update-fluxo-criar-eventos
 roles:
   - Arquiteta Frontend
   - Dev Frontend
@@ -30,4 +31,4 @@ project_context:
   docs_business: docs/business/
   docs_tech: docs/tech/
   docs_context: docs/tech-context/
-  session: docs/.squads/sessions/portal-nexora
+  session: docs/.squads/sessions/fix-update-fluxo-criar-eventos

--- a/docs/.squads/sessions/fix-update-fluxo-criar-eventos/context.md
+++ b/docs/.squads/sessions/fix-update-fluxo-criar-eventos/context.md
@@ -1,0 +1,16 @@
+# Contexto: fix-update-fluxo-criar-eventos
+
+> Arquivo central da feature. Lido por todos os roles antes de executar qualquer step.
+> Atualizado pelo role que fizer discovery/investigação.
+
+## O que é
+{descrição da feature — preenchido na pré-execução ou pelo usuário}
+
+## Por que existe
+{motivação de negócio ou técnica}
+
+## Decisões tomadas
+{decisões já resolvidas — evita retrabalho}
+
+## O que não fazer
+{armadilhas conhecidas, abordagens descartadas}

--- a/docs/.squads/sessions/fix-update-fluxo-criar-eventos/memories.md
+++ b/docs/.squads/sessions/fix-update-fluxo-criar-eventos/memories.md
@@ -1,0 +1,25 @@
+# Memória: fix-update-fluxo-criar-eventos
+
+> Aprendizados acumulados de todos os roles que trabalharam nesta feature.
+> O pipeline-runner carrega apenas o bloco RECENTES por padrão.
+> Para expandir o histórico completo: use /session consolidate.
+>
+> [DECISÃO CRÍTICA] — use este marcador em entradas que NUNCA devem ser comprimidas.
+> Entradas com [DECISÃO CRÍTICA] são permanentes — não são movidas para SUMMARY.
+
+<!-- SUMMARY -->
+<!-- /SUMMARY -->
+
+<!-- RECENTES -->
+## Sessão 2026-05-08
+Task: Bug — evento criado no CMS não refletia em /eventos público
+Issue: —
+
+## [frontend-001 · ana-arquitetura-fe] — 2026-05-08
+
+[DECISÃO CRÍTICA] Padrão aprovado — revalidação de cache após mutação de eventos:
+- Toda Server Action que muta a tabela `events` DEVE chamar `revalidatePath('/eventos')` antes do `redirect`
+- Para edição/exclusão: revalidar também `/eventos/${slug}` para invalidar página de detalhe
+- Padrão: encadear `.select("slug").single()` no `.update()` para obter o slug sem query extra
+- `excluirEvento`: buscar slug ANTES do delete para poder revalidar a página de detalhe
+<!-- /RECENTES -->

--- a/docs/.squads/sessions/fix-update-fluxo-criar-eventos/review-notes.md
+++ b/docs/.squads/sessions/fix-update-fluxo-criar-eventos/review-notes.md
@@ -1,0 +1,5 @@
+# Review Notes: fix-update-fluxo-criar-eventos
+
+> Notas de revisão de todos os roles. Append-only.
+
+(preenchido durante revisões)

--- a/docs/.squads/sessions/fix-update-fluxo-criar-eventos/session.manifest.json
+++ b/docs/.squads/sessions/fix-update-fluxo-criar-eventos/session.manifest.json
@@ -1,0 +1,14 @@
+{
+  "feature": "fix-update-fluxo-criar-eventos",
+  "manifest_version": 2,
+  "created_at": "2026-05-08T00:00:00Z",
+  "files": {
+    "context.md":      { "hash": null, "snapshot_valid": false, "loaded_at": null },
+    "architecture.md": { "hash": null, "snapshot_valid": false, "loaded_at": null },
+    "memories.md":     { "entry_count": 0, "last_entry_at": null }
+  },
+  "adrs": {
+    "loaded_domains": ["*"],
+    "loaded_at": "2026-05-08T00:00:00Z"
+  }
+}

--- a/docs/.squads/sessions/fix-update-fluxo-criar-eventos/state.json
+++ b/docs/.squads/sessions/fix-update-fluxo-criar-eventos/state.json
@@ -1,0 +1,17 @@
+{
+  "feature": "fix-update-fluxo-criar-eventos",
+  "created_at": "2026-05-08T00:00:00Z",
+  "updated_at": "2026-05-08T00:00:00Z",
+  "squads": {
+    "frontend-001": {
+      "domain": "frontend",
+      "pipeline": "bug-fix",
+      "started_at": "2026-05-08T00:00:00Z",
+      "completed_at": "2026-05-08T00:00:00Z",
+      "status": "completed",
+      "completed_steps": ["01-gate-integridade", "bf-02-diagnostico", "bf-03-fix", "bf-04-review"],
+      "current_step": null,
+      "suspended_at": null
+    }
+  }
+}

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/actions.ts
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { ActionState } from "@/lib/supabase/types";
@@ -51,7 +52,7 @@ export async function editarEvento(
     thumbnail_url = publicData.publicUrl;
   }
 
-  const { error } = await adminClient
+  const { data: updated, error } = await adminClient
     .from("events")
     .update({
       title: parsed.data.title,
@@ -65,17 +66,27 @@ export async function editarEvento(
       youtube_url: parsed.data.youtube_url || null,
       updated_at: new Date().toISOString(),
     })
-    .eq("id", id);
+    .eq("id", id)
+    .select("slug")
+    .single();
 
   if (error) {
     return { message: "Erro ao atualizar evento. Tente novamente." };
   }
 
+  revalidatePath("/eventos");
+  if (updated?.slug) revalidatePath(`/eventos/${updated.slug}`);
   redirect("/cms/dashboard/eventos");
 }
 
 export async function excluirEvento(id: string): Promise<ActionState> {
   const adminClient = createAdminClient();
+
+  const { data: evento } = await adminClient
+    .from("events")
+    .select("slug")
+    .eq("id", id)
+    .single();
 
   const { error } = await adminClient.from("events").delete().eq("id", id);
 
@@ -83,5 +94,7 @@ export async function excluirEvento(id: string): Promise<ActionState> {
     return { message: "Erro ao excluir evento. Tente novamente." };
   }
 
+  revalidatePath("/eventos");
+  if (evento?.slug) revalidatePath(`/eventos/${evento.slug}`);
   redirect("/cms/dashboard/eventos");
 }

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/actions.ts
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { ActionState } from "@/lib/supabase/types";
@@ -30,11 +31,15 @@ export async function criarEvento(
     };
   }
 
+  const thumbnailFile = formData.get("thumbnail_file") as File | null;
+  if (!thumbnailFile || thumbnailFile.size === 0) {
+    return { errors: { thumbnail_file: ["Thumbnail é obrigatória"] } };
+  }
+
   const adminClient = createAdminClient();
 
   let thumbnail_url: string | null = null;
-  const thumbnailFile = formData.get("thumbnail_file") as File | null;
-  if (thumbnailFile && thumbnailFile.size > 0) {
+  if (thumbnailFile.size > 0) {
     const ext = thumbnailFile.name.split(".").pop() ?? "jpg";
     const path = `eventos/${Date.now()}.${ext}`;
     const { data: uploadData, error: uploadError } = await adminClient.storage
@@ -68,5 +73,6 @@ export async function criarEvento(
     return { message: "Erro ao criar evento. Tente novamente." };
   }
 
+  revalidatePath("/eventos");
   redirect("/cms/dashboard/eventos");
 }

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/view.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/view.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import { useNovoEventoViewModel } from "./viewModel";
 
 export function NovoEventoView() {
-  const { form, formAction, isPending, state, handleCancel } =
+  const { form, formRef, handleSubmit, isPending, state, handleCancel } =
     useNovoEventoViewModel();
   const {
     register,
@@ -36,7 +36,7 @@ export function NovoEventoView() {
         do título.
       </p>
 
-      <form action={formAction} className={cn("space-y-6")}>
+      <form ref={formRef} onSubmit={handleSubmit} className={cn("space-y-6")}>
         {/* Informações básicas */}
         <Card>
           <CardHeader>
@@ -243,8 +243,13 @@ export function NovoEventoView() {
           </CardHeader>
           <CardContent className={cn("space-y-4")}>
             <div className={cn("space-y-1.5")}>
-              <Label>Thumbnail (opcional)</Label>
+              <Label>Thumbnail</Label>
               <ThumbnailUpload />
+              {state?.errors?.thumbnail_file && (
+                <p className={cn("text-xs text-destructive")}>
+                  {state.errors.thumbnail_file[0]}
+                </p>
+              )}
             </div>
 
             <div className={cn("space-y-1.5")}>

--- a/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/viewModel.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/_features/NovoEvento/viewModel.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useActionState } from "react";
+import { startTransition, useActionState, useRef } from "react";
 import { type UseFormReturn, useForm } from "react-hook-form";
 import type { ActionState } from "@/lib/supabase/types";
 import { criarEvento } from "./actions";
@@ -10,7 +10,8 @@ import { type EventoFormData, eventoSchema } from "./schema";
 
 type NovoEventoViewModel = {
   form: UseFormReturn<EventoFormData>;
-  formAction: (payload: FormData) => void;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  handleSubmit: (e?: React.BaseSyntheticEvent) => void;
   isPending: boolean;
   state: ActionState;
   handleCancel: () => void;
@@ -22,6 +23,8 @@ export function useNovoEventoViewModel(): NovoEventoViewModel {
     criarEvento,
     undefined,
   );
+
+  const formRef = useRef<HTMLFormElement>(null);
 
   const form = useForm<EventoFormData>({
     resolver: zodResolver(eventoSchema),
@@ -36,9 +39,17 @@ export function useNovoEventoViewModel(): NovoEventoViewModel {
     },
   });
 
+  const handleSubmit = form.handleSubmit(() => {
+    const el = formRef.current;
+    if (!el) return;
+    startTransition(() => {
+      formAction(new FormData(el));
+    });
+  });
+
   function handleCancel() {
     router.back();
   }
 
-  return { form, formAction, isPending, state, handleCancel };
+  return { form, formRef, handleSubmit, isPending, state, handleCancel };
 }

--- a/src/app/(publics)/eventos/_features/eventos/EventosGravados.tsx
+++ b/src/app/(publics)/eventos/_features/eventos/EventosGravados.tsx
@@ -1,4 +1,4 @@
-import { PlayCircle, Video } from "lucide-react";
+import { Camera, PlayCircle, Video } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
@@ -71,22 +71,35 @@ export function EventosGravados({ eventos }: Props) {
                     aria-label={`Ver detalhes: ${evento.title}`}
                     className={cn("relative block overflow-hidden aspect-video")}
                   >
-                    <Image
-                      src={evento.thumbnail_url ?? "/images/event-placeholder.jpg"}
-                      alt={evento.title}
-                      fill
-                      className={cn(
-                        "object-cover group-hover:scale-105 transition-transform duration-300",
-                      )}
-                    />
-                    <div
-                      className={cn(
-                        "absolute inset-0 bg-teal-900/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200",
-                      )}
-                      aria-hidden="true"
-                    >
-                      <PlayCircle className={cn("size-12 text-white")} />
-                    </div>
+                    {evento.thumbnail_url ? (
+                      <>
+                        <Image
+                          src={evento.thumbnail_url}
+                          alt={evento.title}
+                          fill
+                          className={cn(
+                            "object-cover group-hover:scale-105 transition-transform duration-300",
+                          )}
+                        />
+                        <div
+                          className={cn(
+                            "absolute inset-0 bg-teal-900/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200",
+                          )}
+                          aria-hidden="true"
+                        >
+                          <PlayCircle className={cn("size-12 text-white")} />
+                        </div>
+                      </>
+                    ) : (
+                      <div
+                        className={cn(
+                          "w-full h-full bg-slate-100 flex items-center justify-center",
+                        )}
+                        aria-hidden="true"
+                      >
+                        <Camera className={cn("size-10 text-slate-300")} />
+                      </div>
+                    )}
                   </Link>
                   <CardHeader>
                     <div className={cn("flex items-center gap-2 mb-1")}>

--- a/src/app/(publics)/eventos/_features/eventos/ProximosEventos.tsx
+++ b/src/app/(publics)/eventos/_features/eventos/ProximosEventos.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, Clock, Video } from "lucide-react";
+import { CalendarDays, Camera, Clock, Video } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
@@ -70,15 +70,24 @@ export function ProximosEventos({ eventos }: Props) {
                 )}
               >
                 <div className={cn("relative")}>
-                  <Image
-                    src={
-                      evento.thumbnail_url ?? "/images/event-placeholder.jpg"
-                    }
-                    alt={evento.title}
-                    width={400}
-                    height={220}
-                    className={cn("w-full h-48 object-cover")}
-                  />
+                  {evento.thumbnail_url ? (
+                    <Image
+                      src={evento.thumbnail_url}
+                      alt={evento.title}
+                      width={400}
+                      height={220}
+                      className={cn("w-full h-48 object-cover")}
+                    />
+                  ) : (
+                    <div
+                      className={cn(
+                        "w-full h-48 bg-slate-100 flex items-center justify-center",
+                      )}
+                      aria-hidden="true"
+                    >
+                      <Camera className={cn("size-10 text-slate-300")} />
+                    </div>
+                  )}
                 </div>
                 <CardHeader>
                   <div className={cn("flex gap-2 flex-wrap mb-1")}>


### PR DESCRIPTION
## Resumo

- **Cache não invalidado**: `criarEvento`, `editarEvento` e `excluirEvento` não chamavam `revalidatePath` após mutação — a página `/eventos` servia dados obsoletos do Full Route Cache
- **Thumbnail obrigatória**: adicionada validação no server action + mensagem de erro na view
- **Imagem quebrada**: substituído fallback `/images/event-placeholder.jpg` por ícone `Camera` nos componentes públicos `ProximosEventos` e `EventosGravados`
- **Formulário resetando no erro**: migrado de `<form action={formAction}>` para `onSubmit` + `startTransition`, preservando o estado do RHF entre tentativas com erro

## Plano de teste

- [ ] Criar evento com status "Publicado" e verificar que aparece em `/eventos` imediatamente
- [ ] Editar evento e verificar que `/eventos` e `/eventos/[slug]` refletem a mudança
- [ ] Excluir evento e verificar que some de `/eventos`
- [ ] Tentar criar evento sem thumbnail e confirmar mensagem de erro
- [ ] Preencher o formulário, submeter com erro (ex: sem thumbnail) e confirmar que os campos não são limpos
- [ ] Verificar que eventos sem thumbnail exibem ícone câmera nos cards públicos (sem imagem quebrada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)