### PR TITLE
## PR 2: feat(auth): implementar página e fluxo de login

### DIFF
--- a/src/app/(auth)/login/_features/login/actions.ts
+++ b/src/app/(auth)/login/_features/login/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { loginSchema } from "./schema";
+import type { ActionState } from "./model";
+import { createClient } from "@/lib/supabase/server";
+
+export async function login( _prev: ActionState | null, formData: FormData ): Promise<ActionState> {
+  const email = formData.get("email")?.toString() || "";
+  const password = formData.get("password")?.toString() || "";
+
+  // Validar com Zod no servidor
+  const parsed = loginSchema.safeParse({ email, password });
+
+  if (!parsed.success) {
+    return { success: false, message: "Dados inválidos. Verifique as informações preenchidas." };
+  }
+
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    
+    if (error) {
+      return { success: false, message: "E-mail ou senha incorretos. Tente novamente." };
+    }
+  } catch (error) {
+    return { success: false, message: "Ocorreu um erro inesperado ao tentar entrar." };
+  }
+
+  // Sucesso com redirecionamento para a área logada
+  redirect("/minha-area");
+}

--- a/src/app/(auth)/login/_features/login/index.tsx
+++ b/src/app/(auth)/login/_features/login/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./view";
+export * from "./model";

--- a/src/app/(auth)/login/_features/login/model.ts
+++ b/src/app/(auth)/login/_features/login/model.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { loginSchema } from "../login/schema";
+
+export type LoginFormData = z.infer<typeof loginSchema>;
+
+export type ActionState = {
+  success: boolean;
+  message: string;
+};

--- a/src/app/(auth)/login/_features/login/schema.ts
+++ b/src/app/(auth)/login/_features/login/schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("E-mail inválido"),
+  password: z.string().min(6, "Senha obrigatória"),
+});

--- a/src/app/(auth)/login/_features/login/view.tsx
+++ b/src/app/(auth)/login/_features/login/view.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { useLoginViewModel } from "./viewModel";
+import Link from "next/link";
+
+export default function LoginView() {
+  const { form, onSubmit, status, isPending } = useLoginViewModel();
+
+  const isLoading = isPending || form.formState.isSubmitting;
+
+  return (
+    <div className={cn("max-w-md w-full mx-auto p-8 bg-white rounded-xl shadow-sm border border-slate-200")}>
+      <div className={cn("mb-8 text-center")}>
+        <h2 className={cn("text-2xl font-bold text-teal-900")}>Bem-vindo de volta</h2>
+        <p className={cn("text-slate-500 mt-2 text-sm")}>Entre para acessar seus cursos e materiais.</p>
+      </div>
+      
+      <form onSubmit={form.handleSubmit(onSubmit)} className={cn("flex flex-col gap-5")}>
+        <div className={cn("flex flex-col gap-2")}>
+          <Label htmlFor="email">E-mail</Label>
+          <Input 
+            id="email" 
+            type="email" 
+            disabled={isLoading}
+            {...form.register("email")} 
+          />
+          {form.formState.errors.email && (
+            <p className={cn("text-sm text-destructive")}>{form.formState.errors.email.message}</p>
+          )}
+        </div>
+
+        <div className={cn("flex flex-col gap-2")}>
+          <div className={cn("flex justify-between items-center")}>
+            <Label htmlFor="password">Senha</Label>
+            <Link href="/recuperar-senha" className={cn("text-xs text-teal-600 hover:text-teal-700 font-medium")}>
+              Esqueceu a senha?
+            </Link>
+          </div>
+          <Input 
+            id="password" 
+            type="password" 
+            disabled={isLoading}
+            {...form.register("password")} 
+          />
+          {form.formState.errors.password && (
+            <p className={cn("text-sm text-destructive")}>{form.formState.errors.password.message}</p>
+          )}
+        </div>
+
+        {status && (
+          <div className={cn("p-3 rounded-md", status.success ? "bg-teal-50 text-teal-800" : "bg-red-50 text-red-800")}>
+            <p className={cn("text-sm font-medium text-center")}>{status.message}</p>
+          </div>
+        )}
+
+        <div className={cn("pt-2")}>
+          <Button type="submit" disabled={isLoading} className={cn("w-full bg-teal-600 hover:bg-teal-700")}>
+            {isLoading ? "Entrando..." : "Entrar"}
+          </Button>
+        </div>
+      </form>
+      
+      <div className={cn("mt-6 text-center")}>
+        <p className={cn("text-sm text-slate-600")}>
+          Ainda não tem conta?{" "}
+          <Link href="/cadastro" className={cn("text-amber-600 hover:text-amber-700 font-semibold transition-colors")}>
+            Cadastrar &rarr;
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/_features/login/viewModel.tsx
+++ b/src/app/(auth)/login/_features/login/viewModel.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useActionState, startTransition } from "react";
+import { useForm, type UseFormReturn, type SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema } from "./schema";
+import { login } from "./actions";
+import type { ActionState, LoginFormData } from "./model";
+
+export type LoginViewModel = {
+  form: UseFormReturn<LoginFormData>;
+  onSubmit: SubmitHandler<LoginFormData>;
+  status: ActionState | null;
+  isPending: boolean;
+};
+
+export function useLoginViewModel(): LoginViewModel {
+  const [status, formAction, isPending] = useActionState(login, null);
+
+  const form = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const onSubmit: SubmitHandler<LoginFormData> = (data) => {
+    const formData = new FormData();
+    formData.append("email", data.email);
+    formData.append("password", data.password);
+    
+    // Aciona a Server Action envelopada em uma transition para capturar isPending corretamente
+    startTransition(() => formAction(formData));
+  };
+
+  return { form, onSubmit, status, isPending };
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import LoginView from "./_features/login/view";
+
+export const metadata: Metadata = {
+  title: "Entrar - NEXORA",
+};
+
+export default function LoginPage() {
+  return (
+    <main className="min-h-screen bg-slate-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <LoginView />
+    </main>
+  );
+}


### PR DESCRIPTION
**Descrição:**
Implementação da página de entrada (`/login`) que serve como porta de acesso para a área restrita do portal, reaproveitando os padrões visuais e arquiteturais.

**O que foi feito:**
- Desenvolvimento da UI de Login com a identidade visual Teal/Amber (ADR-008).
- Validação de formulário via Zod Schema.
- Integração real com `supabase.auth.signInWithPassword` em ambiente server-side (Server Action).
- Tratamento amigável de mensagens de erro para credenciais incorretas.
- Redirecionamento automático para a rota `/minha-area` em caso de sucesso.

**Como testar:**
1. Acessar `/login`.
2. Inserir credenciais inválidas e validar o surgimento do alerta de erro.
3. Inserir credenciais geradas no PR de cadastro.
4. Confirmar o acesso e redirecionamento correto.