### PR TITLE
feat(auth): implementar página e fluxo de cadastro de alunos

### DIFF
--- a/src/app/(auth)/login/_features/login/actions.ts
+++ b/src/app/(auth)/login/_features/login/actions.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { loginSchema } from "./schema";
+import type { ActionState } from "@/lib/supabase/types";
+import { createClient } from "@/lib/supabase/server";
+
+export async function login( _prev: ActionState | null, formData: FormData ): Promise<ActionState> {
+  const email = formData.get("email")?.toString() || "";
+  const password = formData.get("password")?.toString() || "";
+
+  const parsed = loginSchema.safeParse({ email, password });
+
+  if (!parsed.success) {
+    return { success: false, message: "Dados inválidos. Verifique as informações preenchidas." };
+  }
+
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    
+    if (error) {
+      return { success: false, message: "E-mail ou senha incorretos. Tente novamente." };
+    }
+  } catch (error) {
+    return { success: false, message: "Ocorreu um erro inesperado ao tentar entrar." };
+  }
+
+  redirect("/minha-area");
+}

--- a/src/app/(auth)/login/_features/login/index.tsx
+++ b/src/app/(auth)/login/_features/login/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./view";
+export * from "./model";

--- a/src/app/(auth)/login/_features/login/middleware.ts
+++ b/src/app/(auth)/login/_features/login/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  
+  const { supabaseResponse, user } = await updateSession(request);
+
+  const { pathname } = request.nextUrl;
+
+  const loggedInRestrictedRoutes = ["/login", "/cadastro", "/recuperar-senha"];
+  if (user && loggedInRestrictedRoutes.some((route) => pathname.startsWith(route))) {
+    return NextResponse.redirect(new URL("/minha-area", request.url));
+  }
+
+  const privateRoutes = ["/minha-area"];
+  if (!user && privateRoutes.some((route) => pathname.startsWith(route))) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Corresponde a todos os caminhos, exceto:
+     * - _next/static e _next/image
+     * - favicon.ico e imagens estáticas
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/src/app/(auth)/login/_features/login/model.ts
+++ b/src/app/(auth)/login/_features/login/model.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { loginSchema } from "../login/schema";
+
+export type LoginFormData = z.infer<typeof loginSchema>;

--- a/src/app/(auth)/login/_features/login/schema.ts
+++ b/src/app/(auth)/login/_features/login/schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("E-mail inválido"),
+  password: z.string().min(6, "Senha obrigatória"),
+});

--- a/src/app/(auth)/login/_features/login/view.tsx
+++ b/src/app/(auth)/login/_features/login/view.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { useLoginViewModel } from "./viewModel";
+import Link from "next/link";
+
+export default function LoginView() {
+  const { form, onSubmit, status, isPending } = useLoginViewModel();
+
+  const isLoading = isPending || form.formState.isSubmitting;
+
+  return (
+    <div className={cn("max-w-md w-full mx-auto p-8 bg-white rounded-xl shadow-sm border border-slate-200")}>
+      <div className={cn("mb-8 text-center")}>
+        <h2 className={cn("text-2xl font-bold text-teal-900")}>Bem-vindo de volta</h2>
+        <p className={cn("text-slate-500 mt-2 text-sm")}>Entre para acessar seus cursos e materiais.</p>
+      </div>
+      
+      <form onSubmit={form.handleSubmit(onSubmit)} className={cn("flex flex-col gap-5")}>
+        <div className={cn("flex flex-col gap-2")}>
+          <Label htmlFor="email">E-mail</Label>
+          <Input 
+            id="email" 
+            type="email" 
+            disabled={isLoading}
+            {...form.register("email")} 
+          />
+          {form.formState.errors.email && (
+            <p className={cn("text-sm text-destructive")}>{form.formState.errors.email.message}</p>
+          )}
+        </div>
+
+        <div className={cn("flex flex-col gap-2")}>
+          <div className={cn("flex justify-between items-center")}>
+            <Label htmlFor="password">Senha</Label>
+            <Link href="/recuperar-senha" className={cn("text-xs text-teal-600 hover:text-teal-700 font-medium")}>
+              Esqueceu a senha?
+            </Link>
+          </div>
+          <Input 
+            id="password" 
+            type="password" 
+            disabled={isLoading}
+            {...form.register("password")} 
+          />
+          {form.formState.errors.password && (
+            <p className={cn("text-sm text-destructive")}>{form.formState.errors.password.message}</p>
+          )}
+        </div>
+
+        {status && (
+          <div className={cn("p-3 rounded-md", status.success ? "bg-teal-50 text-teal-800" : "bg-red-50 text-red-800")}>
+            <p className={cn("text-sm font-medium text-center")}>{status.message}</p>
+          </div>
+        )}
+
+        <div className={cn("pt-2")}>
+          <Button type="submit" disabled={isLoading} className={cn("w-full bg-teal-600 hover:bg-teal-700")}>
+            {isLoading ? "Entrando..." : "Entrar"}
+          </Button>
+        </div>
+      </form>
+      
+      <div className={cn("mt-6 text-center")}>
+        <p className={cn("text-sm text-slate-600")}>
+          Ainda não tem conta?{" "}
+          <Link href="/cadastro" className={cn("text-amber-600 hover:text-amber-700 font-semibold transition-colors")}>
+            Cadastrar &rarr;
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/_features/login/viewModel.tsx
+++ b/src/app/(auth)/login/_features/login/viewModel.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useActionState, startTransition } from "react";
+import { useForm, type UseFormReturn, type SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema } from "./schema";
+import { login } from "./actions";
+import type { LoginFormData } from "./model";
+import type { ActionState } from "@/lib/supabase/types";
+
+export type LoginViewModel = {
+  form: UseFormReturn<LoginFormData>;
+  onSubmit: SubmitHandler<LoginFormData>;
+  status: ActionState | null;
+  isPending: boolean;
+};
+
+export function useLoginViewModel(): LoginViewModel {
+  const [status, formAction, isPending] = useActionState(login, null);
+
+  const form = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const onSubmit: SubmitHandler<LoginFormData> = (data) => {
+    const formData = new FormData();
+    formData.append("email", data.email);
+    formData.append("password", data.password);
+    
+    // Aciona a Server Action envelopada em uma transition para capturar isPending corretamente
+    startTransition(() => formAction(formData));
+  };
+
+  return { form, onSubmit, status, isPending };
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import LoginView from "./_features/login/view";
+
+export const metadata: Metadata = {
+  title: "Entrar - NEXORA",
+};
+
+export default function LoginPage() {
+  return (
+    <main className="min-h-screen bg-slate-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <LoginView />
+    </main>
+  );
+}

--- a/src/app/(publics)/cadastro/_features/actions.ts
+++ b/src/app/(publics)/cadastro/_features/actions.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { cadastroSchema } from './schema';
+import { createClient } from '@/lib/supabase/server';
+import { ActionState } from '@/lib/supabase/types';
+
+export async function cadastrar(_prev: ActionState, formData: FormData): Promise<ActionState> {
+  const supabase = await createClient();
+  const data = Object.fromEntries(formData.entries());
+  
+  const validatedFields = cadastroSchema.safeParse(data);
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      message: 'Dados inválidos.',
+      errors: validatedFields.error.flatten().fieldErrors,
+    };
+  }
+
+  const { email, password, full_name } = validatedFields.data;
+
+  const { data: signUpData, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: { full_name },
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/minha-area`,
+    },
+  });
+
+  if (error) {
+    return { success: false, message: error.message };
+  }
+
+  if (signUpData.session) {
+    redirect('/minha-area');
+  }
+
+  return {
+    success: true,
+    message: 'Cadastro realizado! Verifique seu e-mail para confirmar a conta.',
+  };
+}

--- a/src/app/(publics)/cadastro/_features/schema.ts
+++ b/src/app/(publics)/cadastro/_features/schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const cadastroSchema = z.object({
+  full_name: z.string().min(2, 'Nome obrigatório'),
+  email: z.string().email('E-mail inválido'),
+  password: z.string().min(6, 'Senha deve ter ao menos 6 caracteres'),
+  confirm_password: z.string(),
+}).refine(data => data.password === data.confirm_password, {
+  message: 'As senhas não coincidem',
+  path: ['confirm_password'],
+});
+
+export type CadastroSchema = z.infer<typeof cadastroSchema>;

--- a/src/app/(publics)/cadastro/_features/view.tsx
+++ b/src/app/(publics)/cadastro/_features/view.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Link from 'next/link';
+import { useCadastroViewModel } from './viewModel';
+import { cn } from '@/lib/utils'; // Ajuste conforme seu helper
+
+export const CadastroView = () => {
+  const { form, state, formAction, isPending } = useCadastroViewModel();
+
+  return (
+    <div className={cn("flex min-h-screen items-center justify-center bg-slate-50 p-4")}>
+      <div className={cn("w-full max-w-md rounded-lg border border-slate-200 bg-white p-8 shadow-sm")}>
+        <h1 className={cn("mb-6 text-2xl font-bold text-teal-700")}>Criar conta</h1>
+        
+        <form action={formAction} className={cn("space-y-4")}>
+          <div className={cn("space-y-1")}>
+            <label className={cn("text-sm font-medium text-slate-700")}>Nome Completo</label>
+            <input
+              {...form.register('full_name')}
+              name="full_name"
+              className={cn("w-full rounded-md border border-slate-300 p-2 focus:border-teal-500 focus:ring-teal-500")}
+            />
+            {form.formState.errors.full_name && (
+              <p className={cn("text-xs text-red-500")}>{form.formState.errors.full_name.message}</p>
+            )}
+          </div>
+
+          <div className={cn("space-y-1")}>
+            <label className={cn("text-sm font-medium text-slate-700")}>E-mail</label>
+            <input
+              {...form.register('email')}
+              name="email"
+              type="email"
+              className={cn("w-full rounded-md border border-slate-300 p-2 focus:border-teal-500 focus:ring-teal-500")}
+            />
+            {form.formState.errors.email && (
+              <p className={cn("text-xs text-red-500")}>{form.formState.errors.email.message}</p>
+            )}
+          </div>
+
+          <div className={cn("space-y-1")}>
+            <label className={cn("text-sm font-medium text-slate-700")}>Senha</label>
+            <input
+              {...form.register('password')}
+              name="password"
+              type="password"
+              className={cn("w-full rounded-md border border-slate-300 p-2 focus:border-teal-500 focus:ring-teal-500")}
+            />
+            {form.formState.errors.password && (
+              <p className={cn("text-xs text-red-500")}>{form.formState.errors.password.message}</p>
+            )}
+          </div>
+
+          <div className={cn("space-y-1")}>
+            <label className={cn("text-sm font-medium text-slate-700")}>Confirmar Senha</label>
+            <input
+              {...form.register('confirm_password')}
+              name="confirm_password"
+              type="password"
+              className={cn("w-full rounded-md border border-slate-300 p-2 focus:border-teal-500 focus:ring-teal-500")}
+            />
+            {form.formState.errors.confirm_password && (
+              <p className={cn("text-xs text-red-500")}>{form.formState.errors.confirm_password.message}</p>
+            )}
+          </div>
+
+          {state?.message && (
+            <p className={cn("text-sm p-3 rounded", state.success ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800")}>
+              {state.message}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className={cn(
+              "w-full rounded-md bg-teal-600 py-2 font-semibold text-white transition-colors hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed",
+              "bg-teal-600 hover:bg-teal-700 active:bg-teal-800"
+            )}
+          >
+            {isPending ? 'Cadastrando...' : 'Criar conta'}
+          </button>
+        </form>
+
+        <p className={cn("mt-6 text-center text-sm text-slate-600")}>
+          Já tem conta?{' '}
+          <Link href="/login" className={cn("font-medium text-amber-600 hover:text-amber-700")}>
+            Entrar →
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/app/(publics)/cadastro/_features/viewModel.tsx
+++ b/src/app/(publics)/cadastro/_features/viewModel.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useActionState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { cadastroSchema, type CadastroSchema } from './schema';
+import { ActionState } from '@/lib/supabase/types';
+import { cadastrar } from './actions';
+
+export const useCadastroViewModel = () => {
+  const initialState: ActionState = { success: false, message: undefined };
+  const [state, formAction, isPending] = useActionState(cadastrar, initialState);
+
+  const form = useForm<CadastroSchema>({
+    resolver: zodResolver(cadastroSchema),
+    defaultValues: {
+      full_name: '',
+      email: '',
+      password: '',
+      confirm_password: '',
+    },
+  });
+
+  return {
+    form,
+    state,
+    formAction,
+    isPending,
+  };
+};

--- a/src/app/(publics)/cadastro/page.tsx
+++ b/src/app/(publics)/cadastro/page.tsx
@@ -1,0 +1,5 @@
+import { CadastroView } from "./_features/view";
+
+export default function CadastroPage() {
+  return <CadastroView />;
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/login");
+}


### PR DESCRIPTION
**Descrição:**
Implementação da página pública de cadastro (`/cadastro`) seguindo rigorosamente a arquitetura MVVM (ADR-004) definida para o projeto.

**O que foi feito:**
- Criação da View e ViewModel de Cadastro com validação client-side e server-side unificada usando Zod e React Hook Form.
- Integração com `supabase.auth.signUp` via Server Actions isoladas (`actions.ts`).
- Criação de Migration SQL (`00002_cadastro_auth_trigger.sql`) contendo o Trigger no banco de dados para a sincronização automática e segura entre `auth.users` e `public.student_profiles`.
- Feedback visual de estados (loading, success, error) gerenciados nativamente com `useActionState` e `startTransition`.

**Como testar:**
1. Rodar a migration `00002_cadastro_auth_trigger.sql` no Supabase.
2. Acessar `/cadastro`.
3. Realizar o cadastro de um usuário válido.
4. Verificar o redirecionamento e a presença do registro na tabela `student_profiles`.