### PR TITLE
feat(auth): implementar página e fluxo de login

### DIFF
--- a/src/app/(auth)/login/_features/login/actions.ts
+++ b/src/app/(auth)/login/_features/login/actions.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { loginSchema } from "./schema";
+import type { ActionState } from "@/lib/supabase/types";
+import { createClient } from "@/lib/supabase/server";
+
+export async function login( _prev: ActionState | null, formData: FormData ): Promise<ActionState> {
+  const email = formData.get("email")?.toString() || "";
+  const password = formData.get("password")?.toString() || "";
+
+  const parsed = loginSchema.safeParse({ email, password });
+
+  if (!parsed.success) {
+    return { success: false, message: "Dados inválidos. Verifique as informações preenchidas." };
+  }
+
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    
+    if (error) {
+      return { success: false, message: "E-mail ou senha incorretos. Tente novamente." };
+    }
+  } catch (error) {
+    return { success: false, message: "Ocorreu um erro inesperado ao tentar entrar." };
+  }
+
+  redirect("/minha-area");
+}

--- a/src/app/(auth)/login/_features/login/index.tsx
+++ b/src/app/(auth)/login/_features/login/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./view";
+export * from "./model";

--- a/src/app/(auth)/login/_features/login/middleware.ts
+++ b/src/app/(auth)/login/_features/login/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  
+  const { supabaseResponse, user } = await updateSession(request);
+
+  const { pathname } = request.nextUrl;
+
+  const loggedInRestrictedRoutes = ["/login", "/cadastro", "/recuperar-senha"];
+  if (user && loggedInRestrictedRoutes.some((route) => pathname.startsWith(route))) {
+    return NextResponse.redirect(new URL("/minha-area", request.url));
+  }
+
+  const privateRoutes = ["/minha-area"];
+  if (!user && privateRoutes.some((route) => pathname.startsWith(route))) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Corresponde a todos os caminhos, exceto:
+     * - _next/static e _next/image
+     * - favicon.ico e imagens estáticas
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/src/app/(auth)/login/_features/login/model.ts
+++ b/src/app/(auth)/login/_features/login/model.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { loginSchema } from "../login/schema";
+
+export type LoginFormData = z.infer<typeof loginSchema>;

--- a/src/app/(auth)/login/_features/login/schema.ts
+++ b/src/app/(auth)/login/_features/login/schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("E-mail inválido"),
+  password: z.string().min(6, "Senha obrigatória"),
+});

--- a/src/app/(auth)/login/_features/login/view.tsx
+++ b/src/app/(auth)/login/_features/login/view.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { useLoginViewModel } from "./viewModel";
+import Link from "next/link";
+
+export default function LoginView() {
+  const { form, onSubmit, status, isPending } = useLoginViewModel();
+
+  const isLoading = isPending || form.formState.isSubmitting;
+
+  return (
+    <div className={cn("max-w-md w-full mx-auto p-8 bg-white rounded-xl shadow-sm border border-slate-200")}>
+      <div className={cn("mb-8 text-center")}>
+        <h2 className={cn("text-2xl font-bold text-teal-900")}>Bem-vindo de volta</h2>
+        <p className={cn("text-slate-500 mt-2 text-sm")}>Entre para acessar seus cursos e materiais.</p>
+      </div>
+      
+      <form onSubmit={form.handleSubmit(onSubmit)} className={cn("flex flex-col gap-5")}>
+        <div className={cn("flex flex-col gap-2")}>
+          <Label htmlFor="email">E-mail</Label>
+          <Input 
+            id="email" 
+            type="email" 
+            disabled={isLoading}
+            {...form.register("email")} 
+          />
+          {form.formState.errors.email && (
+            <p className={cn("text-sm text-destructive")}>{form.formState.errors.email.message}</p>
+          )}
+        </div>
+
+        <div className={cn("flex flex-col gap-2")}>
+          <div className={cn("flex justify-between items-center")}>
+            <Label htmlFor="password">Senha</Label>
+            <Link href="/recuperar-senha" className={cn("text-xs text-teal-600 hover:text-teal-700 font-medium")}>
+              Esqueceu a senha?
+            </Link>
+          </div>
+          <Input 
+            id="password" 
+            type="password" 
+            disabled={isLoading}
+            {...form.register("password")} 
+          />
+          {form.formState.errors.password && (
+            <p className={cn("text-sm text-destructive")}>{form.formState.errors.password.message}</p>
+          )}
+        </div>
+
+        {status && (
+          <div className={cn("p-3 rounded-md", status.success ? "bg-teal-50 text-teal-800" : "bg-red-50 text-red-800")}>
+            <p className={cn("text-sm font-medium text-center")}>{status.message}</p>
+          </div>
+        )}
+
+        <div className={cn("pt-2")}>
+          <Button type="submit" disabled={isLoading} className={cn("w-full bg-teal-600 hover:bg-teal-700")}>
+            {isLoading ? "Entrando..." : "Entrar"}
+          </Button>
+        </div>
+      </form>
+      
+      <div className={cn("mt-6 text-center")}>
+        <p className={cn("text-sm text-slate-600")}>
+          Ainda não tem conta?{" "}
+          <Link href="/cadastro" className={cn("text-amber-600 hover:text-amber-700 font-semibold transition-colors")}>
+            Cadastrar &rarr;
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/_features/login/viewModel.tsx
+++ b/src/app/(auth)/login/_features/login/viewModel.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useActionState, startTransition } from "react";
+import { useForm, type UseFormReturn, type SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema } from "./schema";
+import { login } from "./actions";
+import type { LoginFormData } from "./model";
+import type { ActionState } from "@/lib/supabase/types";
+
+export type LoginViewModel = {
+  form: UseFormReturn<LoginFormData>;
+  onSubmit: SubmitHandler<LoginFormData>;
+  status: ActionState | null;
+  isPending: boolean;
+};
+
+export function useLoginViewModel(): LoginViewModel {
+  const [status, formAction, isPending] = useActionState(login, null);
+
+  const form = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const onSubmit: SubmitHandler<LoginFormData> = (data) => {
+    const formData = new FormData();
+    formData.append("email", data.email);
+    formData.append("password", data.password);
+    
+    // Aciona a Server Action envelopada em uma transition para capturar isPending corretamente
+    startTransition(() => formAction(formData));
+  };
+
+  return { form, onSubmit, status, isPending };
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import LoginView from "./_features/login/view";
+
+export const metadata: Metadata = {
+  title: "Entrar - NEXORA",
+};
+
+export default function LoginPage() {
+  return (
+    <main className="min-h-screen bg-slate-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <LoginView />
+    </main>
+  );
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/login");
+}

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,11 +1,11 @@
-"use client"
-
 import { Menu } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
+import { createClient } from "@/lib/supabase/server"
+import { signOut } from "@/app/actions"
 
 const navLinks = [
   { label: "Início", href: "/" },
@@ -16,7 +16,10 @@ const navLinks = [
   { label: "Contato", href: "/#contato" },
 ]
 
-export function Header() {
+export async function Header() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
   return (
     <header className={cn("bg-teal-900 text-white px-6 py-3 flex items-center justify-between gap-4")}>
       <Link href="/" aria-label="Ir para a página inicial" className={cn("shrink-0")}>
@@ -42,15 +45,46 @@ export function Header() {
             {link.label}
           </Link>
         ))}
+        {user && (
+          <>
+            <Link
+              href="/minha-area"
+              className={cn(
+                "px-3 py-1.5 rounded text-sm font-medium text-amber-500 hover:text-amber-400 hover:bg-white/10 transition-colors",
+              )}
+            >
+              Minha Área
+            </Link>
+            <Link
+              href="/minha-area/perfil"
+              className={cn(
+                "px-3 py-1.5 rounded text-sm font-medium text-amber-500 hover:text-amber-400 hover:bg-white/10 transition-colors",
+              )}
+            >
+              Meu Perfil
+            </Link>
+          </>
+        )}
       </nav>
 
       <div className={cn("hidden md:flex items-center gap-3 shrink-0")}>
-        <Button
-          className={cn("bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold border-0 h-8 px-4 transition-colors")}
-          render={<Link href="/login" />}
-        >
-          Entrar
-        </Button>
+        {user ? (
+          <form action={signOut}>
+            <Button
+              type="submit"
+              className={cn("bg-red-600 hover:bg-red-700 text-white font-bold border-0 h-8 px-4 transition-colors")}
+            >
+              Sair
+            </Button>
+          </form>
+        ) : (
+          <Button
+            className={cn("bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold border-0 h-8 px-4 transition-colors")}
+            render={<Link href="/login" />}
+          >
+            Entrar
+          </Button>
+        )}
       </div>
 
       <Sheet>
@@ -85,15 +119,60 @@ export function Header() {
                   </SheetClose>
                 </li>
               ))}
+              {user && (
+                <>
+                  <li>
+                    <SheetClose
+                      className={cn("w-full text-left")}
+                      render={
+                        <Link
+                          href="/minha-area"
+                          className={cn(
+                            "block px-3 py-2.5 rounded text-sm font-medium text-amber-500 hover:text-amber-400 hover:bg-white/10 transition-colors",
+                          )}
+                        />
+                      }
+                    >
+                      Minha Área
+                    </SheetClose>
+                  </li>
+                  <li>
+                    <SheetClose
+                      className={cn("w-full text-left")}
+                      render={
+                        <Link
+                          href="/minha-area/perfil"
+                          className={cn(
+                            "block px-3 py-2.5 rounded text-sm font-medium text-amber-500 hover:text-amber-400 hover:bg-white/10 transition-colors",
+                          )}
+                        />
+                      }
+                    >
+                      Meu Perfil
+                    </SheetClose>
+                  </li>
+                </>
+              )}
             </ul>
           </nav>
           <div className={cn("p-4 mt-auto border-t border-teal-700")}>
-            <Button
-              className={cn("w-full bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold border-0 transition-colors")}
-              render={<Link href="/login" />}
-            >
-              Entrar
-            </Button>
+            {user ? (
+              <form action={signOut}>
+                <Button
+                  type="submit"
+                  className={cn("w-full bg-red-600 hover:bg-red-700 text-white font-bold border-0 transition-colors")}
+                >
+                  Sair da Conta
+                </Button>
+              </form>
+            ) : (
+              <Button
+                className={cn("w-full bg-amber-500 hover:bg-amber-400 text-teal-900 font-bold border-0 transition-colors")}
+                render={<Link href="/login" />}
+              >
+                Entrar
+              </Button>
+            )}
           </div>
         </SheetContent>
       </Sheet>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,25 +2,44 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { updateSession } from '@/lib/supabase/middleware'
 
 const PUBLIC_CMS_PATHS = ['/cms/login', '/cms/register']
+const PUBLIC_STUDENT_PATHS = ['/login', '/cadastro', '/recuperar-senha']
+const PROTECTED_STUDENT_PATHS = ['/minha-area']
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (PUBLIC_CMS_PATHS.some((p) => pathname.startsWith(p))) {
-    return NextResponse.next()
-  }
-
   const { supabaseResponse, user } = await updateSession(request)
 
-  if (!user) {
-    const loginUrl = request.nextUrl.clone()
-    loginUrl.pathname = '/cms/login'
-    return NextResponse.redirect(loginUrl)
+  // 1. Proteção das rotas do CMS
+  if (pathname.startsWith('/cms')) {
+    const isCmsPublic = PUBLIC_CMS_PATHS.some((p) => pathname.startsWith(p))
+    
+    if (user && isCmsPublic) {
+      return NextResponse.redirect(new URL('/cms/dashboard', request.url))
+    }
+    if (!user && !isCmsPublic) {
+      return NextResponse.redirect(new URL('/cms/login', request.url))
+    }
+    return supabaseResponse
+  }
+
+  // 2. Proteção das rotas da Área do Aluno
+  const isStudentPublic = PUBLIC_STUDENT_PATHS.some((p) => pathname.startsWith(p))
+  const isStudentProtected = PROTECTED_STUDENT_PATHS.some((p) => pathname.startsWith(p))
+
+  if (user && isStudentPublic) {
+    return NextResponse.redirect(new URL('/minha-area/perfil', request.url))
+  }
+  if (!user && isStudentProtected) {
+    return NextResponse.redirect(new URL('/login', request.url))
   }
 
   return supabaseResponse
 }
 
 export const config = {
-  matcher: ['/cms/:path*'],
+  matcher: [
+    // Aplica o middleware em todas as rotas EXCETO arquivos estáticos (.css, imagens, etc)
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
 }


### PR DESCRIPTION
**Descrição:**
Implementação da página de entrada (`/login`) que serve como porta de acesso para a área restrita do portal, reaproveitando os padrões visuais e arquiteturais.

**O que foi feito:**
- Desenvolvimento da UI de Login com a identidade visual Teal/Amber (ADR-008).
- Validação de formulário via Zod Schema.
- Integração real com `supabase.auth.signInWithPassword` em ambiente server-side (Server Action).
- Tratamento amigável de mensagens de erro para credenciais incorretas.
- Redirecionamento automático para a rota `/minha-area` em caso de sucesso.

**Como testar:**
1. Acessar `/login`.
2. Inserir credenciais inválidas e validar o surgimento do alerta de erro.
3. Inserir credenciais geradas no PR de cadastro.
4. Confirmar o acesso e redirecionamento correto.