### PR TITLE
refactor/responsive-privateArea

### DIFF
--- a/.synapos/open-pr.js
+++ b/.synapos/open-pr.js
@@ -1,0 +1,37 @@
+const title = "refactor(layout): estruturação da área logada e refinamento do header público";
+const body = `### 🎯 Objetivo
+Esta PR tem como objetivo refatorar e aprimorar a estrutura de layout e navegação do **Portal Nexora**, dividindo claramente as responsabilidades visuais entre a **Área Pública** e a **Área Logada (Privada)**.
+
+---
+
+### 🛠 Alterações e Funcionalidades Implementadas
+
+#### 1. Área Logada (Privada) - Modelo "Shell"
+- **Novo Layout Estrutural:** O layout da área privada (\`src/app/(private)/layout.tsx\`) foi completamente reescrito para utilizar um design em formato *Shell* dinâmico, baseado na mesma estrutura flexível do nosso CMS.
+- **\`PrivateSidebar\` Nativa:** Implementação de uma barra lateral (\`Sidebar\`) fixa que acomoda:
+  - O logotipo / nome do portal no topo.
+  - Links de navegação exclusivos para o usuário ("Minha Área").
+- **Menu do Usuário (\`PrivateSidebarUserMenu\`):** Adicionado no rodapé da Sidebar.
+  - Faz o carregamento (Server-Side) dos dados do usuário (\`user.profile.full_name\`, \`user.email\` e avatar) diretamente da tabela \`student_profiles\` no Supabase.
+  - Clique no menu abre um *drawer/dropdown* lateral revelando os atalhos "Meu Perfil" e a ação de "Sair".
+- **Limpeza do \`PrivateHeader\`:** O header da área privada tornou-se extremamente limpo e não renderiza elementos redundantes (como logos ou links espalhados), servindo apenas para maximizar o foco do usuário no conteúdo da página.
+
+#### 2. Cabeçalho Público (\`Header\`)
+- **Limpeza da Navbar Principal:** Quando o usuário está autenticado, os atalhos de "Minha Área" e "Meu Perfil" **foram removidos** da lista de navegação global, mantendo a navbar pública imutável e limpa.
+- **Avatar Interativo:** O botão estático de "Entrar" é substituído pela foto de avatar do aluno.
+- **Menu Hover Inteligente:** Ao passar o mouse sobre o avatar do aluno, um submenu flutuante é disparado exibindo os atalhos privados "Minha Área", "Meu Perfil" e "Sair".
+- **Menu Mobile Adaptado:** Links restritos da "Minha Conta" só são renderizados dentro do Menu Hambúrguer caso exista uma sessão ativa.
+
+---
+
+### 🛡️ Mitigações e Melhorias de Arquitetura
+
+- **Prevenção de FOUC e Blink de Autenticação:** A extração do perfil do usuário foi deslocada para a camada \`async\` do \`layout.tsx\` via Server Components. Evita delay de Client-side fetching na Sidebar e previne falhas de UI durante a renderização inicial.
+- **Desempenho no Public Header:** O menu dropdown principal (quando logado) foi construído utilizando *Hover States do Tailwind CSS* (\`group-hover\`), sem a necessidade de converter o arquivo base para \`"use client"\`, economizando JavaScript no client bundle e permitindo renderização estática sever-side.
+- **Componentização Granular:** Separação estrita dos componentes de layout e isolamento completo de navegação pública (\`Header\`) vs navegação privada (\`PrivateSidebar\`).`;
+
+const url = `https://github.com/Instituto-Nexora/Portal_NEXORA/pull/new/refactor/app-structure?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+
+const { exec } = require('child_process');
+// Using start directly which will use the default browser, or specifically msedge
+exec(`start msedge "${url}"`);

--- a/pr-desc.txt
+++ b/pr-desc.txt
@@ -1,0 +1,30 @@
+### 🎯 Objetivo
+Esta PR tem como objetivo refatorar e aprimorar a estrutura de layout e navegação do **Portal Nexora**, dividindo claramente as responsabilidades visuais entre a **Área Pública** e a **Área Logada (Privada)**.
+
+---
+
+### 🛠 Alterações e Funcionalidades Implementadas
+
+#### 1. Área Logada (Privada) - Modelo "Shell"
+- **Novo Layout Estrutural:** O layout da área privada (`src/app/(private)/layout.tsx`) foi completamente reescrito para utilizar um design em formato *Shell* dinâmico, baseado na mesma estrutura flexível do nosso CMS.
+- **`PrivateSidebar` Nativa:** Implementação de uma barra lateral (`Sidebar`) fixa que acomoda:
+  - O logotipo / nome do portal no topo.
+  - Links de navegação exclusivos para o usuário ("Minha Área").
+- **Menu do Usuário (`PrivateSidebarUserMenu`):** Adicionado no rodapé da Sidebar.
+  - Faz o carregamento (Server-Side) dos dados do usuário (`user.profile.full_name`, `user.email` e avatar) diretamente da tabela `student_profiles` no Supabase.
+  - Clique no menu abre um *drawer/dropdown* lateral revelando os atalhos "Meu Perfil" e a ação de "Sair".
+- **Limpeza do `PrivateHeader`:** O header da área privada tornou-se extremamente limpo e não renderiza elementos redundantes (como logos ou links espalhados), servindo apenas para maximizar o foco do usuário no conteúdo da página.
+
+#### 2. Cabeçalho Público (`Header`)
+- **Limpeza da Navbar Principal:** Quando o usuário está autenticado, os atalhos de "Minha Área" e "Meu Perfil" **foram removidos** da lista de navegação global, mantendo a navbar pública imutável e limpa.
+- **Avatar Interativo:** O botão estático de "Entrar" é substituído pela foto de avatar do aluno.
+- **Menu Hover Inteligente:** Ao passar o mouse sobre o avatar do aluno, um submenu flutuante é disparado exibindo os atalhos privados "Minha Área", "Meu Perfil" e "Sair".
+- **Menu Mobile Adaptado:** Links restritos da "Minha Conta" só são renderizados dentro do Menu Hambúrguer caso exista uma sessão ativa.
+
+---
+
+### 🛡️ Mitigações e Melhorias de Arquitetura
+
+- **Prevenção de FOUC e Blink de Autenticação:** A extração do perfil do usuário foi deslocada para a camada `async` do `layout.tsx` via Server Components. Evita delay de Client-side fetching na Sidebar e previne falhas de UI durante a renderização inicial.
+- **Desempenho no Public Header:** O menu dropdown principal (quando logado) foi construído utilizando *Hover States do Tailwind CSS* (`group-hover`), sem a necessidade de converter o arquivo base para `"use client"`, economizando JavaScript no client bundle e permitindo renderização estática sever-side.
+- **Componentização Granular:** Separação estrita dos componentes de layout e isolamento completo de navegação pública (`Header`) vs navegação privada (`PrivateSidebar`).

--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -34,7 +34,7 @@ export default async function PrivateLayout({
       <PrivateSidebar user={sessionUser} className={cn("sticky top-0 h-screen hidden md:flex")} />
 
       <div className={cn("flex flex-1 flex-col overflow-hidden")}>
-        <PrivateHeader />
+        <PrivateHeader user={sessionUser} />
 
         <main className={cn("flex-1 overflow-y-auto p-6 bg-muted/40")}>
           {children}

--- a/src/components/layout/PrivateHeader/PrivateHeader.tsx
+++ b/src/components/layout/PrivateHeader/PrivateHeader.tsx
@@ -1,9 +1,61 @@
+"use client";
+
+import { useState, useEffect } from "react"
+import { Menu } from "lucide-react"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { PrivateSidebarNav } from "@/components/layout/PrivateSidebar/PrivateSidebarNav"
+import { PrivateSidebarUserMenu } from "@/components/layout/PrivateSidebar/PrivateSidebarUserMenu"
+import type { SessionUser } from "@/lib/supabase/types"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils"
 
-export function PrivateHeader() {
+type Props = {
+  user: SessionUser;
+}
+
+export function PrivateHeader({ user }: Props) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Fecha o menu lateral automaticamente ao navegar para outra rota
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
   return (
-    <header className={cn("flex h-14 shrink-0 items-center border-b  px-6")}>
-      {/* O header agora é completamente limpo para maximizar a área de foco do usuário. */}
+    <header className={cn("flex h-14 shrink-0 items-center border-b bg-background px-6")}>
+      {/* Menu Hamburger - Visível apenas no Mobile */}
+      <div className="md:hidden flex items-center">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger className="mr-4 focus:outline-none">
+            <Menu className="size-6 text-foreground" />
+            <span className="sr-only">Abrir menu</span>
+          </SheetTrigger>
+          <SheetContent side="left" className="p-0 flex flex-col w-72 bg-background border-r border-border">
+            <div className={cn("flex h-14 items-center px-5")}>
+              <Link href="/minha-area" onClick={() => setOpen(false)}>
+                <p className="text-xl font-bold tracking-widest text-foreground">NEXORA TI</p>
+              </Link>
+            </div>
+            
+            <Separator />
+            
+            <div className={cn("flex-1 overflow-y-auto py-4")}>
+              <PrivateSidebarNav />
+            </div>
+            
+            <Separator />
+            
+            <div className={cn("py-4")}>
+              <PrivateSidebarUserMenu user={user} />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      {/* Espaço vazio no desktop apenas para manter a barra superior limpa */}
     </header>
   )
 }

--- a/src/components/layout/PrivateSidebar/PrivateSidebarUserMenu.tsx
+++ b/src/components/layout/PrivateSidebar/PrivateSidebarUserMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { UserCircle, LogOut, User, ChevronRight } from "lucide-react";
+import { UserCircle, LogOut, User, ChevronRight, ChevronUp } from "lucide-react";
 import Link from "next/link";
 import { signOut } from "@/app/actions";
 import type { SessionUser } from "@/lib/supabase/types";
@@ -27,9 +27,9 @@ export function PrivateSidebarUserMenu({ user }: Props) {
 
   return (
     <div className={cn("relative px-4")} ref={menuRef}>
-      {/* Dropdown Menu - Aparece ao lado direito */}
+      {/* Dropdown Menu - Responsivo: Abre para cima no mobile, para o lado no desktop */}
       {isOpen && (
-        <div className="absolute left-full bottom-0 ml-2 w-48 bg-background rounded-md shadow-lg border border-border overflow-hidden z-50">
+        <div className="absolute bottom-full left-4 right-4 mb-2 md:bottom-0 md:left-full md:right-auto md:mb-0 md:ml-2 md:w-48 bg-background rounded-md shadow-lg border border-border overflow-hidden z-50">
           <div className="py-1 flex flex-col">
             <Link
               href="/perfil"
@@ -81,7 +81,10 @@ export function PrivateSidebarUserMenu({ user }: Props) {
             {user.email}
           </p>
         </div>
-        <ChevronRight className={cn("size-4 text-muted-foreground transition-transform duration-200", isOpen && "rotate-180")} />
+        {/* Ícone Desktop */}
+        <ChevronRight className={cn("hidden md:block size-4 text-muted-foreground transition-transform duration-200", isOpen && "rotate-180")} />
+        {/* Ícone Mobile */}
+        <ChevronUp className={cn("md:hidden size-4 text-muted-foreground transition-transform duration-200", isOpen && "rotate-180")} />
       </button>
     </div>
   );


### PR DESCRIPTION
refactor(layout): implementação de responsividade na área logada

Melhorias de UI/UX implementadas:
1. Navegação Mobile (Menu Hambúrguer):
- O componente `PrivateHeader` foi recriado para telas menores (`md:hidden` nos elementos internos).
- Agora, no mobile, exibe-se um ícone de menu (Hamburger) que, ao ser clicado, abre um painel deslizante lateral (gaveta / Sheet).
- A gaveta mobile carrega exatamente o mesmo conteúdo da Sidebar (Navegação + Menu de Usuário), mantendo consistência entre os dispositivos.
- Lógica inteligente no `PrivateHeader` escuta mudanças de rota (`usePathname`) e fecha o menu lateral automaticamente quando o usuário clica em algum link.

2. Ajuste Fino do Menu do Usuário (Rodapé):
- O comportamento do `PrivateSidebarUserMenu` agora é totalmente responsivo.
- Em telas de Desktop, o painel de "Meu Perfil / Sair" continua abrindo para a direita (`left-full`).
- Em telas Mobile, o painel abre inteligentemente para cima (`bottom-full`), respeitando os limites da tela (Sheet).
- O ícone direcional do botão acompanha o layout (`ChevronRight` no desktop e `ChevronUp` no mobile).