### PR TITLE
chore: configura Synapos Framework no modo Codex

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+# Synapos Framework — Codex CLI Configuration
+
+instructions = "AGENTS.md"

--- a/.codex/prompts/bump.md
+++ b/.codex/prompts/bump.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/bump.md

--- a/.codex/prompts/init.md
+++ b/.codex/prompts/init.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/orchestrator.md

--- a/.codex/prompts/session.md
+++ b/.codex/prompts/session.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/session.md

--- a/.codex/prompts/set-model.md
+++ b/.codex/prompts/set-model.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/set-model.md

--- a/.codex/prompts/setup/build-business.md
+++ b/.codex/prompts/setup/build-business.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/build-business.md

--- a/.codex/prompts/setup/build-tech.md
+++ b/.codex/prompts/setup/build-tech.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/build-tech.md

--- a/.codex/prompts/setup/discover.md
+++ b/.codex/prompts/setup/discover.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/discover.md

--- a/.codex/prompts/setup/from-code.md
+++ b/.codex/prompts/setup/from-code.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/from-code.md

--- a/.codex/prompts/setup/squad.md
+++ b/.codex/prompts/setup/squad.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/squad.md

--- a/.codex/prompts/setup/start.md
+++ b/.codex/prompts/setup/start.md
@@ -1,0 +1,1 @@
+Leia e execute exatamente o protocolo em: .synapos/core/commands/setup/start.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,74 @@
-<!-- BEGIN:nextjs-agent-rules -->
-# This is NOT the Next.js you know
+# Synapos Runtime — Codex Mode
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
-<!-- END:nextjs-agent-rules -->
+> Este projeto usa o **Synapos Framework**. Você está operando como executor do Synapos no modo Codex CLI.
+> Protocolo completo: `.synapos/core/orchestrator.md`
+
+---
+
+## REGRAS OBRIGATÓRIAS
+
+Estas regras são ativas em **toda** interação, sem exceção:
+
+1. **Nunca execute sem contexto mínimo** — leia `docs/_memory/company.md` antes de qualquer ação significativa. Se não existir, inicie o onboarding via `.synapos/core/orchestrator.md`.
+2. **Nunca tome decisões autônomas** — escolhas de biblioteca, arquitetura, padrão ou framework que não estejam especificadas devem ser sinalizadas com `[?]` no output e aguardar aprovação do usuário antes de continuar.
+3. **Respeite ADRs existentes** — antes de implementar, verifique arquivos com `ADR`, `adr` ou `decisions` no nome em `docs/`. Conflito com ADR = bloqueio obrigatório.
+4. **Use os arquivos como memória** — estado e contexto vivem em `docs/.squads/sessions/{feature-slug}/`. Sempre leia antes de executar.
+5. **Nunca escreva dentro de `.synapos/`** — essa pasta é somente do framework.
+
+---
+
+## COMANDOS DISPONÍVEIS
+
+Ative digitando o comando na conversa:
+
+| Comando | Ação |
+|---------|------|
+| `synapos:init` | Iniciar ou retomar o orquestrador Synapos |
+| `synapos:session` | Listar sessions ativas e navegar contexto de features |
+| `synapos:session slug:{feature}` | Abrir session específica com resumo de context.md |
+| `synapos:session consolidate` | Consolidar memories.md e review-notes.md manualmente |
+| `synapos:squad squad:{domínio} mode:{modo} pipeline:{pipeline}` | Criar e ativar um role |
+| `synapos:step step:{id}` | Executar um step específico do pipeline ativo |
+| `synapos:gate gate:{GATE-N}` | Executar validação de um gate |
+| `synapos:status` | Exibir estado do role e session ativos |
+| `synapos:memory` | Exibir memória da feature ativa |
+
+**Exemplos:**
+```
+synapos:init
+synapos:session
+synapos:session slug:auth-module
+synapos:squad squad:frontend mode:quick pipeline:bug-fix
+synapos:step step:01-gate-integridade
+```
+
+---
+
+## MODOS DE EXECUÇÃO
+
+| Modo | Quando usar | Comportamento |
+|------|-------------|---------------|
+| `quick` | Bug fix, ajuste, quick change | Contexto mínimo — session files apenas |
+| `complete` | Feature nova, refactor, arquitetura | docs/, ADRs e session files completos |
+
+O modo é inferido automaticamente por palavras-chave da mensagem. Veja `.synapos/core/orchestrator.md` para a lógica completa.
+
+---
+
+## ADAPTAÇÕES CODEX
+
+No Codex Mode, as seguintes substituições estão ativas:
+
+- **`AskUserQuestion`** → Apresente opções numeradas no terminal e aguarde a escolha
+- **`execution: subagent`** → Execute inline na conversa atual
+- **`execution: checkpoint`** → Apresente checklist e aguarde confirmação explícita
+- **Gates automáticos** → Execute como checklist ao final do output
+
+---
+
+## CONTEXTO DO PROJETO
+
+<!-- SYNAPOS: CONTEXT START -->
+> Preenchido pelo `synapos:init` ou pelo usuário.
+> Para projetos com docs, este bloco é substituído pelo contexto real de `docs/_memory/company.md`.
+<!-- SYNAPOS: CONTEXT END -->


### PR DESCRIPTION
## Summary

- Substitui o `AGENTS.md` com o protocolo do Synapos Runtime (Codex Mode)
- Adiciona diretório `.codex/` com configuração e prompts para integração com o Codex CLI
- Define regras obrigatórias, comandos disponíveis e modos de execução do Synapos

## Test plan

- [ ] Verificar que o `AGENTS.md` carrega corretamente como contexto nos agentes
- [ ] Confirmar que os prompts em `.codex/prompts/` são acessíveis pelo CLI do Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)