### PR TITLE
Admin(CMS): add CMS profile route and sidebar fixes

### DIFF
--- a/docs/.squads/sessions/cms-profile-sidebar-events/architecture.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/architecture.md
@@ -1,0 +1,84 @@
+# Arquitetura — cms-profile-sidebar-events
+
+> Gerado em: 2026-05-12 | Squad: frontend-001
+> Decisões aprovadas pelo usuário: entrega incremental, hooks em `src/hooks`, sidebar Shadcn adaptada ao stack atual.
+
+## ADRs aplicadas
+
+- [RESPEITADA] ADR-001 — Next.js App Router: novas rotas em `src/app/(cms)/cms/dashboard/...`; `page.tsx` segue Server Component.
+- [RESPEITADA] ADR-003 — Tailwind v4: sem `tailwind.config.js`; ajustes via classes e tokens existentes.
+- [RESPEITADA] ADR-004 — MVVM Page Architecture: rota de perfil com `_features/Perfil` contendo `view.tsx`, `viewModel.tsx`, `schema.ts`, `actions.ts` e `model.ts`.
+- [RESPEITADA] ADR-005 — Type-only: usar `type`, nunca `interface`.
+- [RESPEITADA] ADR-006 — Utils: funções puras compartilhadas em `src/utils/` se necessário.
+- [RESPEITADA] ADR-007 — `cn()` em `className`.
+- [RESPEITADA] ADR-008 — identidade Deep Teal + Amber preservada nos CTAs e estados principais.
+
+## Escopo funcional aprovado
+
+Entrega incremental para as issues #80, #68 e #70:
+
+1. Sidebar CMS
+   - Criar componente `src/components/ui/sidebar.tsx` compatível com a composição Shadcn: `SidebarProvider`, `Sidebar`, `SidebarInset`, `SidebarTrigger`, grupos e menu.
+   - Migrar `CMSShell`, `Sidebar`, `SidebarNav`, `SidebarUserMenu` e `TopBar` para o novo padrão.
+   - Remover dependência do drawer mobile manual, usando o provider/trigger da sidebar.
+
+2. Perfil CMS
+   - Criar rota `/cms/dashboard/perfil`.
+   - Criar UI incremental com dados pessoais, avatar, preferências de tema/fonte, segurança e zona de perigo.
+   - Persistir nome/avatar via Supabase server actions.
+   - Usar cooldown de 2h persistido em Supabase Auth metadata para não bloquear a entrega por migration pendente.
+   - Deixar OTP real e exclusão definitiva de conta como bloqueios explicitados/documentados para próxima etapa.
+
+3. Avatar
+   - Upload para bucket `avatars` em path estável por usuário (`admin-profiles/{userId}/avatar.ext`) com `upsert`, substituindo arquivo anterior.
+   - Atualizar `profiles.avatar_url` e metadados Auth.
+
+4. Acessibilidade visual
+   - Hooks globais em `src/hooks/useTheme.ts` e `src/hooks/useChangeFont.ts`.
+   - Persistência em `localStorage` e aplicação no `documentElement`.
+
+5. Responsividade do formulário de edição de evento
+   - Ajustar header, grid de campos, cards e ações para mobile.
+   - Manter RHF/Zod e estrutura existente.
+
+6. Documentação/migrations
+   - Criar SQL de referência em `src/databases/00004_cms_profile_preferences.sql` com bucket avatars, colunas opcionais de cooldown e políticas.
+   - Criar notas da feature na session.
+
+## Arquivos autorizados para modificar/criar
+
+- `src/components/layout/globals.css`
+- `src/components/ui/sidebar.tsx`
+- `src/components/ui/dropdown-menu.tsx`
+- `src/components/ui/avatar.tsx`
+- `src/components/ui/progress.tsx`
+- `src/components/ui/input-otp.tsx`
+- `src/hooks/useTheme.ts`
+- `src/hooks/useChangeFont.ts`
+- `src/components/cms/CMSShell.tsx`
+- `src/components/cms/Sidebar/index.tsx`
+- `src/components/cms/Sidebar/SidebarNav.tsx`
+- `src/components/cms/Sidebar/SidebarUserMenu.tsx`
+- `src/components/cms/TopBar/index.tsx`
+- `src/components/cms/CMSMobileSidebar.tsx`
+- `src/app/(cms)/cms/dashboard/perfil/page.tsx`
+- `src/app/(cms)/cms/dashboard/perfil/loading.tsx`
+- `src/app/(cms)/cms/dashboard/perfil/_features/Perfil/actions.ts`
+- `src/app/(cms)/cms/dashboard/perfil/_features/Perfil/index.tsx`
+- `src/app/(cms)/cms/dashboard/perfil/_features/Perfil/model.ts`
+- `src/app/(cms)/cms/dashboard/perfil/_features/Perfil/schema.ts`
+- `src/app/(cms)/cms/dashboard/perfil/_features/Perfil/view.tsx`
+- `src/app/(cms)/cms/dashboard/perfil/_features/Perfil/viewModel.tsx`
+- `src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/view.tsx`
+- `src/databases/00004_cms_profile_preferences.sql`
+- `docs/.squads/sessions/cms-profile-sidebar-events/feature-notes.md`
+- `docs/.squads/sessions/cms-profile-sidebar-events/review-notes.md`
+- `docs/.squads/sessions/cms-profile-sidebar-events/memories.md`
+- `docs/.squads/sessions/cms-profile-sidebar-events/state.json`
+- `docs/.squads/sessions/cms-profile-sidebar-events/session.manifest.json`
+
+## Riscos e mitigação
+
+- Shadcn doc aponta instalação por CLI; para evitar dependência Radix extra e preservar stack Base UI, a sidebar será implementada localmente com API compatível.
+- OTP e exclusão de conta real exigem decisão/configuração de fluxo Supabase Auth/admin. Serão sinalizados na UI e documentados como próxima etapa.
+- Cooldown em metadata Auth evita quebrar ambientes sem migration aplicada. SQL opcional documenta colunas em `profiles` para endurecimento futuro.

--- a/docs/.squads/sessions/cms-profile-sidebar-events/context.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/context.md
@@ -1,0 +1,36 @@
+# Contexto: cms-profile-sidebar-events
+
+> Arquivo central da feature. Lido por todos os roles antes de executar qualquer step.
+> Criado em: 2026-05-12 | Squad: frontend-001
+
+## O que é
+Implementar melhorias no CMS relacionadas a perfil de usuário, dropdown/rota de perfil, troca de foto, sidebar Shadcn UI e responsividade do formulário de edição de eventos.
+
+Escopo solicitado pelo usuário:
+- GitHub #80 — DropDown / rota de perfil do usuário (CMS), acessibilidade, tema, fonte, dados pessoais, avatar, senha com OTP, skeleton.
+- GitHub #68 — Mudança de foto de perfil com Supabase Storage e troca automática da foto anterior.
+- GitHub #70 — Rota de perfil do usuário com dados, senha, fonte global, exclusão de conta, restrições e toasts.
+- Ajustar responsividade no formulário de edição de evento.
+- Alterar a sidebar do CMS para a Sidebar do Shadcn UI conforme https://ui.shadcn.com/docs/components/radix/sidebar.
+
+## Por que existe
+Administradores precisam gerenciar dados pessoais e preferências de acessibilidade no CMS, e a navegação/admin precisa ficar mais consistente, acessível e responsiva.
+
+## Decisões tomadas
+- Role ativo: frontend-001.
+- Session de trabalho: docs/.squads/sessions/cms-profile-sidebar-events/.
+- Não foi alterado `.synapos/squads/frontend-001/squad.yaml`, pois as instruções do projeto proíbem escrita dentro de `.synapos/`.
+- O trabalho deve respeitar ADRs aceitas: App Router, Tailwind v4 via CSS, MVVM, type-only, utils reutilizáveis e cn() em className.
+
+## O que não fazer
+- Não criar Pages Router.
+- Não colocar `"use client"` em `page.tsx`.
+- Não criar `tailwind.config.js`.
+- Não usar `interface`.
+- Não escrever dentro de `.synapos/`.
+- Não expor Supabase Service Role Key no cliente.
+
+## Pendências de decisão
+[?] Definir se a entrega desta sessão será incremental/MVP ou implementação integral com backend completo (Storage, OTP, cooldown de 2h e exclusão de conta).
+[?] Definir se a Sidebar Shadcn será adicionada via CLI/registry (`npx shadcn add sidebar`) ou implementada manualmente adaptada ao estilo Base UI já usado no projeto.
+[?] Definir local dos hooks globais: issue #80 pede `/src/app/hooks/useTheme.ts`, enquanto components.json usa alias `@/hooks` para `src/hooks` e a issue #70 sugere `src/hooks`.

--- a/docs/.squads/sessions/cms-profile-sidebar-events/context.snapshot
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/context.snapshot
@@ -1,0 +1,1 @@
+CMS: perfil/dropdown/avatar, sidebar Shadcn e responsividade de edição de eventos. Há decisões pendentes sobre escopo backend, método de instalação da sidebar e local de hooks globais.

--- a/docs/.squads/sessions/cms-profile-sidebar-events/feature-notes.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/feature-notes.md
@@ -1,0 +1,37 @@
+# Feature Notes — cms-profile-sidebar-events
+
+## Entrega realizada
+
+- Criada rota `/cms/dashboard/perfil` com skeleton/loading, MVVM e server actions.
+- Adicionados componentes UI locais:
+  - `sidebar.tsx`
+  - `dropdown-menu.tsx`
+  - `avatar.tsx`
+  - `progress.tsx`
+  - `input-otp.tsx`
+- CMS Shell/Sidebar/TopBar migrados para composição de Sidebar Shadcn-like com provider, trigger e sidebar colapsável.
+- Menu do usuário passou a ter dropdown com link de perfil, preferências rápidas de tema/fonte e logout.
+- Criados hooks globais `useTheme` e `useChangeFont` em `src/hooks` com persistência em LocalStorage.
+- Criada UI de perfil com:
+  - dados pessoais;
+  - upload de avatar para Supabase Storage;
+  - preferências de tema/fonte;
+  - validação visual de força de senha;
+  - OTP component preparado e bloqueio seguro enquanto OTP real não está conectado;
+  - modal de zona de perigo sem ação destrutiva real nesta etapa.
+- Formulário de edição de evento ajustado para mobile/responsivo.
+- Criada migration de referência `src/databases/00004_cms_profile_preferences.sql` para bucket `avatars`, políticas e colunas opcionais de cooldown.
+
+## Validação
+
+- `npm run build` — passou.
+- `./node_modules/.bin/biome check <arquivos alterados>` — passou.
+- `npm run lint` global — falhou por problemas preexistentes fora do escopo:
+  - `.synapos/.manifest.json` possui JSON inválido;
+  - `.synapos/open-pr.js` e arquivos antigos de `src/app/(auth)/cadastro` têm erros/avisos Biome.
+
+## Pendências fora do escopo incremental
+
+- Conectar envio/verificação real de OTP por e-mail no Supabase antes de liberar alteração de senha.
+- Implementar exclusão definitiva de conta com validação de senha e operação admin segura.
+- Aplicar e validar migration em ambiente Supabase.

--- a/docs/.squads/sessions/cms-profile-sidebar-events/memories.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/memories.md
@@ -1,0 +1,26 @@
+# Memória: cms-profile-sidebar-events
+
+> Aprendizados acumulados de todos os roles que trabalharam nesta feature.
+> O pipeline-runner carrega apenas o bloco RECENTES por padrão.
+> Para expandir o histórico completo: use /session consolidate.
+>
+> [DECISÃO CRÍTICA] — use este marcador em entradas que NUNCA devem ser comprimidas.
+> Entradas com [DECISÃO CRÍTICA] são permanentes — não são movidas para SUMMARY.
+
+<!-- SUMMARY -->
+<!-- /SUMMARY -->
+
+<!-- RECENTES -->
+## Sessão 2026-05-12
+Task: Realizar issues #80, #68 e #70; ajustar responsividade do formulário de edição de evento; trocar sidebar do CMS para Sidebar Shadcn UI.
+Issue: GitHub #80, #68, #70 | Instituto-Nexora/Portal_NEXORA
+
+## [frontend-001 · gate-integridade] — 2026-05-12
+GATE-0 executado: company.md, squad frontend-001, agents, project-briefing e critical-rules existem. ADRs frontend carregadas e sem conflito inicial. Session criada sem escrever em `.synapos/`.
+
+## [frontend-001 · rodrigo-react] — 2026-05-12
+Implementação incremental concluída: sidebar CMS Shadcn-like, rota /cms/dashboard/perfil, hooks de tema/fonte, avatar upload preparado, responsividade no formulário de edição de evento e migration SQL 00004. OTP real e exclusão definitiva permanecem como próxima etapa segura.
+
+## [frontend-001 · rodrigo-react] — 2026-05-12
+Bug-fix visual pós-teste: removido scroll externo horizontal/vertical no CMS, adicionado scroll interno estilizado (`nexora-scrollbar`), ajustada responsividade/min-width da página de perfil e corrigido estado colapsado da sidebar para ocultar labels e preservar a logo.
+<!-- /RECENTES -->

--- a/docs/.squads/sessions/cms-profile-sidebar-events/memories.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/memories.md
@@ -23,4 +23,7 @@ Implementação incremental concluída: sidebar CMS Shadcn-like, rota /cms/dashb
 
 ## [frontend-001 · rodrigo-react] — 2026-05-12
 Bug-fix visual pós-teste: removido scroll externo horizontal/vertical no CMS, adicionado scroll interno estilizado (`nexora-scrollbar`), ajustada responsividade/min-width da página de perfil e corrigido estado colapsado da sidebar para ocultar labels e preservar a logo.
+
+## [frontend-001 · rodrigo-react] — 2026-05-15
+Continuação dos ajustes visuais da sidebar/perfil: no mobile, o bloco com avatar/nome/e-mail deixou de abrir dropdown e passou a exibir ações explícitas; no desktop, o gatilho do menu do usuário ganhou cursor/indicador visual; a sidebar colapsada recebeu alinhamento centralizado dos ícones e tooltips nos itens clicáveis; o avatar foi padronizado em componente visual Shadcn-like.
 <!-- /RECENTES -->

--- a/docs/.squads/sessions/cms-profile-sidebar-events/review-notes.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/review-notes.md
@@ -40,3 +40,20 @@ Nenhum blocker encontrado. `npm run build` passou após correções de scroll/si
 
 - Scroll externo do CMS foi convertido para scroll interno com barra estilizada.
 - Sidebar colapsada agora preserva ícones e logo sem exibir letras truncadas dos labels.
+
+
+## [frontend-001 · renata-revisao-fe] — 2026-05-15 · continuação ajustes sidebar
+
+### BLOCKER
+
+Nenhum blocker encontrado. `npm run build` passou após os ajustes de avatar, dropdown mobile, cursor/indicador do menu do usuário, tooltips e alinhamento no modo colapsado.
+
+### SUGGESTION
+
+- Retestar visualmente a sidebar em desktop colapsado/expandido e em mobile para confirmar que o bloco do usuário não aciona dropdown no sheet.
+- Validar visualmente se os tooltips da navegação aparecem à direita quando a sidebar está minimizada.
+
+### PRAISE
+
+- A área do usuário no mobile ficou estática e evita quebra por dropdown.
+- Itens clicáveis da sidebar minimizada agora possuem tooltip e melhor indicação de interação.

--- a/docs/.squads/sessions/cms-profile-sidebar-events/review-notes.md
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/review-notes.md
@@ -1,0 +1,42 @@
+# Review Notes: cms-profile-sidebar-events
+
+> Notas de revisão de todos os roles. Append-only.
+
+## [frontend-001 · renata-revisao-fe] — 2026-05-12
+
+### BLOCKER
+
+Nenhum blocker encontrado nos arquivos alterados. `npm run build` passou com Next.js 16.2.4.
+
+### SUGGESTION
+
+- Aplicar a migration `src/databases/00004_cms_profile_preferences.sql` antes de testar upload real de avatar em ambiente Supabase, pois o bucket `avatars` precisa existir.
+- Planejar uma segunda etapa para OTP real por e-mail e exclusão definitiva de conta, pois foram deixados bloqueados por segurança conforme escopo incremental aprovado.
+- Corrigir o lint global do projeto fora do escopo desta feature: `.synapos/.manifest.json` inválido e arquivos antigos de cadastro/auth possuem avisos/erros Biome.
+
+### QUESTION
+
+- A política futura de exclusão de conta deve remover também conteúdos/eventos criados pelo admin ou apenas desativar o acesso?
+
+### PRAISE
+
+- Sidebar migrada para composição Shadcn-like sem nova dependência externa.
+- Rota de perfil segue MVVM e mantém `page.tsx` como Server Component.
+- Arquivos alterados nesta feature passam em Biome scoped check.
+
+
+## [frontend-001 · renata-revisao-fe] — 2026-05-12 · bug-fix visual
+
+### BLOCKER
+
+Nenhum blocker encontrado. `npm run build` passou após correções de scroll/sidebar/perfil.
+
+### SUGGESTION
+
+- Retestar visualmente `/cms/dashboard` e `/cms/dashboard/perfil` com sidebar expandida e colapsada.
+- Se ainda houver overflow horizontal, verificar componentes específicos com conteúdo dinâmico longo (ex.: e-mail ou slugs).
+
+### PRAISE
+
+- Scroll externo do CMS foi convertido para scroll interno com barra estilizada.
+- Sidebar colapsada agora preserva ícones e logo sem exibir letras truncadas dos labels.

--- a/docs/.squads/sessions/cms-profile-sidebar-events/session.manifest.json
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/session.manifest.json
@@ -1,0 +1,38 @@
+{
+  "feature": "cms-profile-sidebar-events",
+  "manifest_version": 2,
+  "created_at": "2026-05-12T23:38:16.164342Z",
+  "files": {
+    "context.md": {
+      "hash": "2305-1778629096",
+      "snapshot_valid": true,
+      "loaded_at": "2026-05-12T23:38:16.164342Z"
+    },
+    "architecture.md": {
+      "hash": "4681-1778631520",
+      "snapshot_valid": false,
+      "loaded_at": "2026-05-13T00:18:40.835319Z"
+    },
+    "memories.md": {
+      "entry_count": 4,
+      "last_entry_at": "2026-05-13T00:18:40.835319Z"
+    },
+    "review-notes.md": {
+      "hash": "1773-1778631520",
+      "snapshot_valid": false,
+      "loaded_at": "2026-05-13T00:18:40.835319Z"
+    },
+    "feature-notes.md": {
+      "hash": "1806-1778630667",
+      "snapshot_valid": false,
+      "loaded_at": "2026-05-13T00:04:28.018357Z"
+    }
+  },
+  "adrs": {
+    "loaded_domains": [
+      "frontend",
+      "*"
+    ],
+    "loaded_at": "2026-05-12T23:38:16.164342Z"
+  }
+}

--- a/docs/.squads/sessions/cms-profile-sidebar-events/session.manifest.json
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/session.manifest.json
@@ -14,8 +14,8 @@
       "loaded_at": "2026-05-13T00:18:40.835319Z"
     },
     "memories.md": {
-      "entry_count": 4,
-      "last_entry_at": "2026-05-13T00:18:40.835319Z"
+      "entry_count": 5,
+      "last_entry_at": "2026-05-15T14:17:25Z"
     },
     "review-notes.md": {
       "hash": "1773-1778631520",

--- a/docs/.squads/sessions/cms-profile-sidebar-events/state.json
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/state.json
@@ -1,0 +1,23 @@
+{
+  "feature": "cms-profile-sidebar-events",
+  "created_at": "2026-05-12T23:38:16.164342Z",
+  "updated_at": "2026-05-13T00:18:40.835319Z",
+  "squads": {
+    "frontend-001": {
+      "domain": "frontend",
+      "pipeline": "feature-development",
+      "started_at": "2026-05-12T23:38:16.164342Z",
+      "completed_at": "2026-05-13T00:04:28.018357Z",
+      "status": "completed",
+      "completed_steps": [
+        "01-gate-integridade",
+        "02-arquitetura",
+        "04-implementacao",
+        "05-review",
+        "06-docs"
+      ],
+      "current_step": null,
+      "suspended_at": null
+    }
+  }
+}

--- a/docs/.squads/sessions/cms-profile-sidebar-events/state.json
+++ b/docs/.squads/sessions/cms-profile-sidebar-events/state.json
@@ -1,7 +1,7 @@
 {
   "feature": "cms-profile-sidebar-events",
   "created_at": "2026-05-12T23:38:16.164342Z",
-  "updated_at": "2026-05-13T00:18:40.835319Z",
+  "updated_at": "2026-05-15T14:17:25Z",
   "squads": {
     "frontend-001": {
       "domain": "frontend",

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/view.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/_features/EditarEvento/view.tsx
@@ -8,10 +8,20 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { Event } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import { DeleteEventoDialog } from "../DeleteEventoDialog/view";
@@ -34,16 +44,24 @@ export function EditarEventoView({ evento }: Props) {
   const tipo = watch("type");
 
   return (
-    <div className={cn("mx-auto max-w-2xl py-8 px-4")}>
-      <div className={cn("flex items-start justify-between mb-8")}>
+    <div className={cn("mx-auto w-full max-w-4xl px-0 py-4 sm:py-8")}>
+      <div
+        className={cn(
+          "mb-6 flex flex-col gap-4 sm:mb-8 sm:flex-row sm:items-start sm:justify-between",
+        )}
+      >
         <div>
-          <h1 className={cn("text-2xl font-bold tracking-tight mb-1")}>
+          <h1
+            className={cn("mb-1 text-2xl font-bold tracking-tight sm:text-3xl")}
+          >
             Editar evento
           </h1>
-          <div className={cn("flex items-center gap-2")}>
+          <div className={cn("flex min-w-0 flex-wrap items-center gap-2")}>
             <span className={cn("text-sm text-muted-foreground")}>Slug:</span>
-            <Badge variant="secondary">
-              <code className={cn("font-mono text-xs")}>{evento.slug}</code>
+            <Badge variant="secondary" className={cn("max-w-full")}>
+              <code className={cn("truncate font-mono text-xs")}>
+                {evento.slug}
+              </code>
             </Badge>
           </div>
         </div>
@@ -52,7 +70,7 @@ export function EditarEventoView({ evento }: Props) {
 
       <form action={formAction} className={cn("space-y-6")}>
         {/* Informações básicas */}
-        <Card>
+        <Card className={cn("overflow-hidden")}>
           <CardHeader>
             <CardTitle>Informações básicas</CardTitle>
           </CardHeader>
@@ -99,13 +117,16 @@ export function EditarEventoView({ evento }: Props) {
               </Label>
               <Textarea
                 id="long_description"
-                rows={4}
+                rows={5}
                 {...register("long_description")}
-                className={cn({
-                  "border-destructive":
-                    errors.long_description ||
-                    state?.errors?.long_description,
-                })}
+                className={cn([
+                  "min-h-32 resize-y",
+                  {
+                    "border-destructive":
+                      errors.long_description ||
+                      state?.errors?.long_description,
+                  },
+                ])}
               />
             </div>
           </CardContent>
@@ -114,12 +135,12 @@ export function EditarEventoView({ evento }: Props) {
         <Separator />
 
         {/* Configurações */}
-        <Card>
+        <Card className={cn("overflow-hidden")}>
           <CardHeader>
             <CardTitle>Configurações</CardTitle>
           </CardHeader>
           <CardContent className={cn("space-y-4")}>
-            <div className={cn("grid grid-cols-2 gap-4")}>
+            <div className={cn("grid gap-4 sm:grid-cols-2")}>
               <div className={cn("space-y-1.5")}>
                 <Label htmlFor="type">Tipo</Label>
                 <Controller
@@ -224,9 +245,7 @@ export function EditarEventoView({ evento }: Props) {
                   >
                     ⓘ
                   </TooltipTrigger>
-                  <TooltipContent>
-                    Duração estimada em minutos
-                  </TooltipContent>
+                  <TooltipContent>Duração estimada em minutos</TooltipContent>
                 </Tooltip>
               </div>
               <Input
@@ -236,8 +255,7 @@ export function EditarEventoView({ evento }: Props) {
                 {...register("duration_minutes")}
                 className={cn({
                   "border-destructive":
-                    errors.duration_minutes ||
-                    state?.errors?.duration_minutes,
+                    errors.duration_minutes || state?.errors?.duration_minutes,
                 })}
               />
             </div>
@@ -247,7 +265,7 @@ export function EditarEventoView({ evento }: Props) {
         <Separator />
 
         {/* Mídia */}
-        <Card>
+        <Card className={cn("overflow-hidden")}>
           <CardHeader>
             <CardTitle>Mídia</CardTitle>
           </CardHeader>
@@ -300,11 +318,24 @@ export function EditarEventoView({ evento }: Props) {
           </Alert>
         )}
 
-        <div className={cn("flex gap-3 pt-2")}>
-          <Button type="submit" disabled={isPending} className={cn("flex-1")}>
+        <div
+          className={cn(
+            "sticky bottom-0 -mx-4 flex flex-col-reverse gap-3 border-t bg-background/95 px-4 py-4 backdrop-blur sm:static sm:mx-0 sm:flex-row sm:border-t-0 sm:bg-transparent sm:px-0 sm:pt-2 sm:backdrop-blur-none",
+          )}
+        >
+          <Button
+            type="submit"
+            disabled={isPending}
+            className={cn("w-full sm:flex-1")}
+          >
             {isPending ? "Salvando…" : "Salvar alterações"}
           </Button>
-          <Button type="button" variant="outline" onClick={handleCancel}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+            className={cn("w-full sm:w-auto")}
+          >
             Cancelar
           </Button>
         </div>

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/actions.ts
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/actions.ts
@@ -1,0 +1,324 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import type { PerfilActionState } from "./model";
+import { perfilSchema, senhaSchema } from "./schema";
+
+const COOLDOWN_MS = 2 * 60 * 60 * 1000;
+const AVATAR_BUCKET = "avatars";
+const PROFILE_METADATA_KEY = "cms_profile_last_changed_at";
+const AVATAR_METADATA_KEY = "cms_avatar_last_changed_at";
+const PASSWORD_METADATA_KEY = "cms_password_last_changed_at";
+
+type CooldownKey =
+  | typeof PROFILE_METADATA_KEY
+  | typeof AVATAR_METADATA_KEY
+  | typeof PASSWORD_METADATA_KEY;
+
+type AuthMetadata = Record<string, unknown>;
+
+function getIsoMetadata(metadata: AuthMetadata, key: CooldownKey) {
+  const value = metadata[key];
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return value;
+}
+
+function getCooldownMessage(lastChangedAt: string | null) {
+  if (!lastChangedAt) {
+    return null;
+  }
+
+  const nextChangeAt = new Date(lastChangedAt).getTime() + COOLDOWN_MS;
+  const remainingMs = nextChangeAt - Date.now();
+
+  if (remainingMs <= 0) {
+    return null;
+  }
+
+  const remainingMinutes = Math.ceil(remainingMs / 60000);
+  const hours = Math.floor(remainingMinutes / 60);
+  const minutes = remainingMinutes % 60;
+  const readable = hours > 0 ? `${hours}h ${minutes}min` : `${minutes}min`;
+
+  return `Aguarde ${readable} para alterar novamente.`;
+}
+
+function getFileExtension(file: File) {
+  const extension = file.name.split(".").pop()?.toLowerCase();
+
+  if (!extension) {
+    return "jpg";
+  }
+
+  if (["jpg", "jpeg", "png", "webp"].includes(extension)) {
+    return extension;
+  }
+
+  return "jpg";
+}
+
+async function getAuthenticatedUser() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabase, user };
+}
+
+export async function atualizarPerfil(
+  _prevState: PerfilActionState,
+  formData: FormData,
+): Promise<PerfilActionState> {
+  const { supabase, user } = await getAuthenticatedUser();
+
+  if (!user) {
+    return {
+      formId: "perfil",
+      success: false,
+      message: "Usuário não autenticado.",
+    };
+  }
+
+  const parsed = perfilSchema.safeParse({
+    full_name: formData.get("full_name"),
+  });
+
+  if (!parsed.success) {
+    return {
+      formId: "perfil",
+      success: false,
+      message: "Revise os dados informados.",
+      errors: parsed.error.flatten((issue) => issue.message)
+        .fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const adminClient = createAdminClient();
+  const { data: profile } = await adminClient
+    .from("profiles")
+    .select("full_name")
+    .eq("user_id", user.id)
+    .single();
+
+  if (profile?.full_name === parsed.data.full_name) {
+    return {
+      formId: "perfil",
+      success: false,
+      message: "Informe um nome diferente do nome atual.",
+    };
+  }
+
+  const metadata = (user.user_metadata ?? {}) as AuthMetadata;
+  const cooldownMessage = getCooldownMessage(
+    getIsoMetadata(metadata, PROFILE_METADATA_KEY),
+  );
+
+  if (cooldownMessage) {
+    return { formId: "perfil", success: false, message: cooldownMessage };
+  }
+
+  const now = new Date().toISOString();
+  const { error: authError } = await supabase.auth.updateUser({
+    data: {
+      ...metadata,
+      full_name: parsed.data.full_name,
+      [PROFILE_METADATA_KEY]: now,
+    },
+  });
+
+  if (authError) {
+    return {
+      formId: "perfil",
+      success: false,
+      message: "Falha ao atualizar metadados do usuário.",
+    };
+  }
+
+  const { error: profileError } = await adminClient
+    .from("profiles")
+    .update({ full_name: parsed.data.full_name })
+    .eq("user_id", user.id);
+
+  if (profileError) {
+    return {
+      formId: "perfil",
+      success: false,
+      message: "Falha ao sincronizar o perfil no CMS.",
+    };
+  }
+
+  revalidatePath("/cms/dashboard/perfil");
+  revalidatePath("/cms/dashboard");
+
+  return {
+    formId: "perfil",
+    success: true,
+    message: "Nome atualizado com sucesso.",
+  };
+}
+
+export async function atualizarAvatar(
+  _prevState: PerfilActionState,
+  formData: FormData,
+): Promise<PerfilActionState> {
+  const { supabase, user } = await getAuthenticatedUser();
+
+  if (!user) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "Usuário não autenticado.",
+    };
+  }
+
+  const file = formData.get("avatar_file");
+
+  if (!(file instanceof File) || file.size === 0) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "Selecione uma imagem para enviar.",
+    };
+  }
+
+  if (!file.type.startsWith("image/")) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "Envie um arquivo de imagem válido.",
+    };
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "A imagem deve ter até 5MB.",
+    };
+  }
+
+  const metadata = (user.user_metadata ?? {}) as AuthMetadata;
+  const cooldownMessage = getCooldownMessage(
+    getIsoMetadata(metadata, AVATAR_METADATA_KEY),
+  );
+
+  if (cooldownMessage) {
+    return { formId: "avatar", success: false, message: cooldownMessage };
+  }
+
+  const adminClient = createAdminClient();
+  const extension = getFileExtension(file);
+  const path = `admin-profiles/${user.id}/avatar.${extension}`;
+  const { data: uploadData, error: uploadError } = await adminClient.storage
+    .from(AVATAR_BUCKET)
+    .upload(path, file, {
+      contentType: file.type,
+      upsert: true,
+    });
+
+  if (uploadError || !uploadData) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "Erro ao enviar avatar. Verifique se o bucket avatars existe.",
+    };
+  }
+
+  const { data: publicData } = adminClient.storage
+    .from(AVATAR_BUCKET)
+    .getPublicUrl(uploadData.path);
+  const avatarUrl = `${publicData.publicUrl}?v=${Date.now()}`;
+  const now = new Date().toISOString();
+
+  const { error: profileError } = await adminClient
+    .from("profiles")
+    .update({ avatar_url: avatarUrl })
+    .eq("user_id", user.id);
+
+  if (profileError) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "Avatar enviado, mas falhou ao salvar no perfil.",
+    };
+  }
+
+  const { error: authError } = await supabase.auth.updateUser({
+    data: {
+      ...metadata,
+      avatar_url: avatarUrl,
+      [AVATAR_METADATA_KEY]: now,
+    },
+  });
+
+  if (authError) {
+    return {
+      formId: "avatar",
+      success: false,
+      message: "Avatar salvo, mas falhou ao atualizar metadados.",
+    };
+  }
+
+  revalidatePath("/cms/dashboard/perfil");
+  revalidatePath("/cms/dashboard");
+
+  return {
+    formId: "avatar",
+    success: true,
+    message: "Foto de perfil atualizada com sucesso.",
+  };
+}
+
+export async function alterarSenha(
+  _prevState: PerfilActionState,
+  formData: FormData,
+): Promise<PerfilActionState> {
+  const { user } = await getAuthenticatedUser();
+
+  if (!user) {
+    return {
+      formId: "senha",
+      success: false,
+      message: "Usuário não autenticado.",
+    };
+  }
+
+  const parsed = senhaSchema.safeParse({
+    new_password: formData.get("new_password"),
+    confirm_password: formData.get("confirm_password"),
+    otp_code: formData.get("otp_code") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return {
+      formId: "senha",
+      success: false,
+      message: parsed.error.issues[0]?.message ?? "Revise os dados informados.",
+      errors: parsed.error.flatten((issue) => issue.message)
+        .fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const metadata = (user.user_metadata ?? {}) as AuthMetadata;
+  const cooldownMessage = getCooldownMessage(
+    getIsoMetadata(metadata, PASSWORD_METADATA_KEY),
+  );
+
+  if (cooldownMessage) {
+    return { formId: "senha", success: false, message: cooldownMessage };
+  }
+
+  return {
+    formId: "senha",
+    success: false,
+    message:
+      "OTP real por e-mail ainda precisa ser conectado ao fluxo Supabase antes de liberar alteração de senha.",
+  };
+}

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/index.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/index.tsx
@@ -1,0 +1,1 @@
+export { PerfilView } from "./view";

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/model.ts
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/model.ts
@@ -1,0 +1,30 @@
+import type { FontSizeMode } from "@/hooks/useChangeFont";
+import type { ThemeMode } from "@/hooks/useTheme";
+import type { AdminRole } from "@/lib/supabase/types";
+
+type PerfilInitialData = {
+  userId: string;
+  email: string;
+  fullName: string;
+  role: AdminRole;
+  avatarUrl: string | null;
+  nextProfileChangeAt: string | null;
+  nextAvatarChangeAt: string | null;
+  theme: ThemeMode;
+  fontSize: FontSizeMode;
+};
+
+type PerfilActionState = {
+  formId: "perfil" | "avatar" | "senha" | "conta";
+  success: boolean;
+  message: string;
+  errors?: Record<string, string[]>;
+} | null;
+
+type PasswordStrength = {
+  score: number;
+  label: string;
+  className: string;
+};
+
+export type { PerfilActionState, PerfilInitialData, PasswordStrength };

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/schema.ts
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/schema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const perfilSchema = z.object({
+  full_name: z
+    .string()
+    .trim()
+    .min(2, "Informe pelo menos 2 caracteres.")
+    .max(80, "Use no máximo 80 caracteres."),
+});
+
+const senhaSchema = z
+  .object({
+    new_password: z
+      .string()
+      .min(8, "A senha deve ter pelo menos 8 caracteres.")
+      .regex(/[A-Z]/, "Inclua ao menos uma letra maiúscula.")
+      .regex(/[a-z]/, "Inclua ao menos uma letra minúscula.")
+      .regex(/[0-9]/, "Inclua ao menos um número."),
+    confirm_password: z.string().min(1, "Confirme a senha."),
+    otp_code: z.string().optional(),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    path: ["confirm_password"],
+    message: "As senhas não conferem.",
+  });
+
+export type PerfilFormData = z.infer<typeof perfilSchema>;
+export type SenhaFormData = z.infer<typeof senhaSchema>;
+export { perfilSchema, senhaSchema };

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/view.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/view.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import {
+  AlertTriangle,
+  Camera,
+  CheckCircle2,
+  Clock,
+  KeyRound,
+  ShieldAlert,
+  Trash2,
+  UserCircle,
+} from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import type { PerfilInitialData } from "./model";
+import { usePerfilViewModel } from "./viewModel";
+
+const OTP_SLOTS = ["otp-1", "otp-2", "otp-3", "otp-4", "otp-5", "otp-6"];
+
+type Props = {
+  initialData: PerfilInitialData;
+};
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+}
+
+function CooldownHint({ value }: { value: string | null }) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <p
+      className={cn(["flex items-center gap-1 text-xs text-muted-foreground"])}
+    >
+      <Clock className={cn(["size-3"])} />
+      Próxima alteração liberada após {new Date(value).toLocaleString("pt-BR")}.
+    </p>
+  );
+}
+
+export function PerfilView({ initialData }: Props) {
+  const {
+    formPerfil,
+    onSubmitPerfil,
+    statusPerfil,
+    isPendingPerfil,
+    statusAvatar,
+    avatarFormAction,
+    isPendingAvatar,
+    avatarPreview,
+    handleAvatarPreview,
+    formSenha,
+    onSubmitSenha,
+    statusSenha,
+    isPendingSenha,
+    passwordStrength,
+    theme,
+    setTheme,
+    fontSize,
+    fontOptions,
+    setFontSize,
+  } = usePerfilViewModel({ initialData });
+  const initials = getInitials(initialData.fullName) || "NX";
+  const avatarUrl = avatarPreview ?? initialData.avatarUrl;
+
+  return (
+    <div className={cn(["min-w-0 space-y-6 overflow-hidden"])}>
+      <div
+        className={cn([
+          "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between",
+        ])}
+      >
+        <div className={cn(["min-w-0 space-y-1"])}>
+          <h1 className={cn(["text-2xl font-bold tracking-tight sm:text-3xl"])}>
+            Meu perfil
+          </h1>
+          <p className={cn(["max-w-2xl text-sm text-muted-foreground"])}>
+            Gerencie dados pessoais, foto de perfil, acessibilidade visual e
+            segurança da conta do CMS.
+          </p>
+        </div>
+        <div
+          className={cn([
+            "rounded-full border bg-muted px-3 py-1 text-xs text-muted-foreground",
+          ])}
+        >
+          Perfil CMS · {initialData.role}
+        </div>
+      </div>
+
+      <div
+        className={cn([
+          "grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]",
+        ])}
+      >
+        <div className={cn(["min-w-0 space-y-6"])}>
+          <Card className={cn(["overflow-hidden"])}>
+            <CardHeader>
+              <CardTitle className={cn(["flex items-center gap-2"])}>
+                <UserCircle className={cn(["size-5 text-primary"])} />
+                Dados pessoais
+              </CardTitle>
+              <CardDescription>
+                Alterações de nome têm intervalo mínimo de 2 horas para evitar
+                inconsistências.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form
+                onSubmit={formPerfil.handleSubmit(onSubmitPerfil)}
+                className={cn(["grid gap-5"])}
+              >
+                <div className={cn(["grid min-w-0 gap-4 lg:grid-cols-2"])}>
+                  <div className={cn(["min-w-0 space-y-2"])}>
+                    <Label htmlFor="full_name">Nome completo</Label>
+                    <Input
+                      id="full_name"
+                      autoComplete="name"
+                      disabled={isPendingPerfil}
+                      {...formPerfil.register("full_name")}
+                    />
+                    {formPerfil.formState.errors.full_name && (
+                      <p className={cn(["text-xs text-destructive"])}>
+                        {formPerfil.formState.errors.full_name.message}
+                      </p>
+                    )}
+                    <CooldownHint value={initialData.nextProfileChangeAt} />
+                  </div>
+                  <div className={cn(["min-w-0 space-y-2"])}>
+                    <Label htmlFor="email">E-mail</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={initialData.email}
+                      disabled
+                      readOnly
+                    />
+                    <p className={cn(["text-xs text-muted-foreground"])}>
+                      O e-mail é gerenciado pelo Supabase Auth.
+                    </p>
+                  </div>
+                </div>
+
+                {statusPerfil?.formId === "perfil" && (
+                  <Alert
+                    variant={statusPerfil.success ? "default" : "destructive"}
+                  >
+                    <AlertDescription>{statusPerfil.message}</AlertDescription>
+                  </Alert>
+                )}
+
+                <div className={cn(["flex justify-end"])}>
+                  <Button
+                    type="submit"
+                    disabled={isPendingPerfil}
+                    className={cn(["w-full sm:w-auto"])}
+                  >
+                    {isPendingPerfil ? "Salvando..." : "Salvar dados"}
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card id="preferencias" className={cn(["overflow-hidden"])}>
+            <CardHeader>
+              <CardTitle>Acessibilidade visual</CardTitle>
+              <CardDescription>
+                Preferências rápidas persistidas localmente para tema e tamanho
+                geral da fonte.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={cn(["grid gap-6"])}>
+              <div className={cn(["space-y-3"])}>
+                <Label>Tema</Label>
+                <div className={cn(["grid gap-2 sm:grid-cols-3"])}>
+                  {[
+                    { value: "system", label: "Sistema" },
+                    { value: "light", label: "Claro" },
+                    { value: "dark", label: "Escuro" },
+                  ].map((item) => (
+                    <Button
+                      key={item.value}
+                      type="button"
+                      variant={theme === item.value ? "default" : "outline"}
+                      onClick={() => setTheme(item.value as typeof theme)}
+                      className={cn(["justify-start"])}
+                    >
+                      {theme === item.value && (
+                        <CheckCircle2 className={cn(["size-4"])} />
+                      )}
+                      {item.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <Separator />
+
+              <div className={cn(["space-y-3"])}>
+                <Label>Tamanho da fonte</Label>
+                <div
+                  className={cn(["grid gap-2 sm:grid-cols-2 lg:grid-cols-4"])}
+                >
+                  {fontOptions.map((option) => (
+                    <Button
+                      key={option.value}
+                      type="button"
+                      variant={
+                        fontSize === option.value ? "default" : "outline"
+                      }
+                      onClick={() => setFontSize(option.value)}
+                      className={cn(["h-auto flex-col items-start gap-1 py-3"])}
+                    >
+                      <span>{option.label}</span>
+                      <span className={cn(["text-xs opacity-75"])}>
+                        {option.description}
+                      </span>
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className={cn(["overflow-hidden"])}>
+            <CardHeader>
+              <CardTitle className={cn(["flex items-center gap-2"])}>
+                <KeyRound className={cn(["size-5 text-primary"])} />
+                Segurança
+              </CardTitle>
+              <CardDescription>
+                Validação de senha preparada. O envio real fica bloqueado até o
+                OTP por e-mail estar conectado.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form
+                onSubmit={formSenha.handleSubmit(onSubmitSenha)}
+                className={cn(["grid gap-5"])}
+              >
+                <Alert>
+                  <AlertTriangle className={cn(["size-4"])} />
+                  <AlertDescription>
+                    Próxima etapa: conectar envio/verificação de OTP por e-mail
+                    antes de liberar alteração real da senha.
+                  </AlertDescription>
+                </Alert>
+                <div className={cn(["grid min-w-0 gap-4 lg:grid-cols-2"])}>
+                  <div className={cn(["min-w-0 space-y-2"])}>
+                    <Label htmlFor="new_password">Nova senha</Label>
+                    <Input
+                      id="new_password"
+                      type="password"
+                      autoComplete="new-password"
+                      disabled={isPendingSenha}
+                      {...formSenha.register("new_password")}
+                    />
+                    {formSenha.formState.errors.new_password && (
+                      <p className={cn(["text-xs text-destructive"])}>
+                        {formSenha.formState.errors.new_password.message}
+                      </p>
+                    )}
+                  </div>
+                  <div className={cn(["min-w-0 space-y-2"])}>
+                    <Label htmlFor="confirm_password">Confirmar senha</Label>
+                    <Input
+                      id="confirm_password"
+                      type="password"
+                      autoComplete="new-password"
+                      disabled={isPendingSenha}
+                      {...formSenha.register("confirm_password")}
+                    />
+                    {formSenha.formState.errors.confirm_password && (
+                      <p className={cn(["text-xs text-destructive"])}>
+                        {formSenha.formState.errors.confirm_password.message}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div className={cn(["min-w-0 space-y-2"])}>
+                  <div
+                    className={cn(["flex items-center justify-between gap-3"])}
+                  >
+                    <Label>Força da senha</Label>
+                    <span className={cn(["text-xs text-muted-foreground"])}>
+                      {passwordStrength.label}
+                    </span>
+                  </div>
+                  <Progress
+                    value={passwordStrength.score}
+                    indicatorClassName={passwordStrength.className}
+                  />
+                </div>
+
+                <div className={cn(["min-w-0 space-y-2"])}>
+                  <Label>Código OTP</Label>
+                  <InputOTP length={6} disabled className={cn(["max-w-full"])}>
+                    <InputOTPGroup className={cn(["flex-wrap"])}>
+                      {OTP_SLOTS.map((slot, index) => (
+                        <InputOTPSlot key={slot} index={index} />
+                      ))}
+                    </InputOTPGroup>
+                  </InputOTP>
+                </div>
+
+                {statusSenha?.formId === "senha" && (
+                  <Alert
+                    variant={statusSenha.success ? "default" : "destructive"}
+                  >
+                    <AlertDescription>{statusSenha.message}</AlertDescription>
+                  </Alert>
+                )}
+
+                <div className={cn(["flex justify-end"])}>
+                  <Button
+                    type="submit"
+                    variant="outline"
+                    disabled={isPendingSenha}
+                    className={cn(["w-full sm:w-auto"])}
+                  >
+                    Validar fluxo de senha
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+
+        <aside className={cn(["min-w-0 space-y-6"])}>
+          <Card className={cn(["overflow-hidden"])}>
+            <CardHeader>
+              <CardTitle>Foto de perfil</CardTitle>
+              <CardDescription>
+                A nova imagem substitui automaticamente a anterior no Storage.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form action={avatarFormAction} className={cn(["space-y-5"])}>
+                <div
+                  className={cn([
+                    "flex flex-col items-center gap-3 text-center",
+                  ])}
+                >
+                  <Avatar
+                    size="lg"
+                    className={cn([
+                      "size-28 border-4 border-background shadow-md ring-1 ring-border",
+                    ])}
+                  >
+                    {avatarUrl && (
+                      <AvatarImage src={avatarUrl} alt={initialData.fullName} />
+                    )}
+                    <AvatarFallback
+                      className={cn([
+                        "bg-primary text-2xl font-bold text-primary-foreground",
+                      ])}
+                    >
+                      {initials}
+                    </AvatarFallback>
+                    <AvatarBadge className={cn(["size-7 bg-primary"])}>
+                      <Camera className={cn(["size-3.5"])} aria-hidden="true" />
+                    </AvatarBadge>
+                  </Avatar>
+                  <div className={cn(["space-y-1"])}>
+                    <p className={cn(["text-sm font-medium"])}>
+                      {initialData.fullName}
+                    </p>
+                    <p className={cn(["text-xs text-muted-foreground"])}>
+                      {initialData.email}
+                    </p>
+                  </div>
+                </div>
+
+                <div className={cn(["min-w-0 space-y-2"])}>
+                  <Label htmlFor="avatar_file">Nova foto</Label>
+                  <Input
+                    id="avatar_file"
+                    name="avatar_file"
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    disabled={isPendingAvatar}
+                    onChange={handleAvatarPreview}
+                  />
+                  <p className={cn(["text-xs text-muted-foreground"])}>
+                    PNG, JPG ou WebP até 5MB.
+                  </p>
+                  <CooldownHint value={initialData.nextAvatarChangeAt} />
+                </div>
+
+                {statusAvatar?.formId === "avatar" && (
+                  <Alert
+                    variant={statusAvatar.success ? "default" : "destructive"}
+                  >
+                    <AlertDescription>{statusAvatar.message}</AlertDescription>
+                  </Alert>
+                )}
+
+                <Button
+                  type="submit"
+                  disabled={isPendingAvatar}
+                  className={cn(["w-full"])}
+                >
+                  <Camera className={cn(["size-4"])} />
+                  {isPendingAvatar ? "Enviando..." : "Atualizar foto"}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card className={cn(["border-destructive/30"])}>
+            <CardHeader>
+              <CardTitle
+                className={cn(["flex items-center gap-2 text-destructive"])}
+              >
+                <ShieldAlert className={cn(["size-5"])} />
+                Zona de perigo
+              </CardTitle>
+              <CardDescription>
+                Exclusão definitiva exige modal de confirmação e operação admin
+                segura.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Dialog>
+                <DialogTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      className={cn(["w-full"])}
+                    />
+                  }
+                >
+                  <Trash2 className={cn(["size-4"])} />
+                  Excluir conta
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Exclusão não pode ser desfeita</DialogTitle>
+                    <DialogDescription>
+                      Para cumprir a regra da issue #70, este modal antecipa o
+                      aviso obrigatório. A ação real será conectada na próxima
+                      etapa com validação de senha e operação admin.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <Alert variant="destructive">
+                    <AlertDescription>
+                      Nenhuma conta será excluída nesta entrega incremental.
+                    </AlertDescription>
+                  </Alert>
+                  <DialogFooter>
+                    <Button type="button" variant="outline" disabled>
+                      Aguardando fluxo seguro
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/viewModel.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/viewModel.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as React from "react";
+import { startTransition, useActionState } from "react";
+import {
+  type SubmitHandler,
+  type UseFormReturn,
+  useForm,
+} from "react-hook-form";
+import { toast } from "sonner";
+import { useChangeFont } from "@/hooks/useChangeFont";
+import { useTheme } from "@/hooks/useTheme";
+import { alterarSenha, atualizarAvatar, atualizarPerfil } from "./actions";
+import type {
+  PasswordStrength,
+  PerfilActionState,
+  PerfilInitialData,
+} from "./model";
+import {
+  type PerfilFormData,
+  perfilSchema,
+  type SenhaFormData,
+  senhaSchema,
+} from "./schema";
+
+type UsePerfilViewModelParams = {
+  initialData: PerfilInitialData;
+};
+
+type PerfilViewModel = {
+  formPerfil: UseFormReturn<PerfilFormData>;
+  onSubmitPerfil: SubmitHandler<PerfilFormData>;
+  statusPerfil: PerfilActionState;
+  isPendingPerfil: boolean;
+  statusAvatar: PerfilActionState;
+  avatarFormAction: (payload: FormData) => void;
+  isPendingAvatar: boolean;
+  avatarPreview: string | null;
+  handleAvatarPreview: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  formSenha: UseFormReturn<SenhaFormData>;
+  onSubmitSenha: SubmitHandler<SenhaFormData>;
+  statusSenha: PerfilActionState;
+  isPendingSenha: boolean;
+  passwordStrength: PasswordStrength;
+  theme: ReturnType<typeof useTheme>["theme"];
+  setTheme: ReturnType<typeof useTheme>["setTheme"];
+  fontSize: ReturnType<typeof useChangeFont>["fontSize"];
+  fontOptions: ReturnType<typeof useChangeFont>["options"];
+  setFontSize: ReturnType<typeof useChangeFont>["setFontSize"];
+};
+
+function getPasswordStrength(password: string): PasswordStrength {
+  const checks = [
+    password.length >= 8,
+    /[A-Z]/.test(password),
+    /[a-z]/.test(password),
+    /[0-9]/.test(password),
+    /[^A-Za-z0-9]/.test(password),
+  ];
+  const score = checks.filter(Boolean).length;
+
+  if (score <= 1) {
+    return { score: 20, label: "Senha ruim", className: "bg-red-800" };
+  }
+
+  if (score === 2 || score === 3) {
+    return { score: 50, label: "Senha média", className: "bg-orange-800" };
+  }
+
+  if (score === 4) {
+    return { score: 75, label: "Senha boa", className: "bg-green-800" };
+  }
+
+  return { score: 100, label: "Senha excelente", className: "bg-emerald-800" };
+}
+
+function notifyStatus(status: PerfilActionState) {
+  if (!status?.message) {
+    return;
+  }
+
+  if (status.success) {
+    toast.success(status.message);
+    return;
+  }
+
+  toast.error(status.message);
+}
+
+function usePerfilViewModel({
+  initialData,
+}: UsePerfilViewModelParams): PerfilViewModel {
+  const [statusPerfil, formActionPerfil, isPendingPerfil] = useActionState(
+    atualizarPerfil,
+    null,
+  );
+  const [statusAvatar, avatarFormAction, isPendingAvatar] = useActionState(
+    atualizarAvatar,
+    null,
+  );
+  const [statusSenha, formActionSenha, isPendingSenha] = useActionState(
+    alterarSenha,
+    null,
+  );
+  const [avatarPreview, setAvatarPreview] = React.useState<string | null>(null);
+  const { theme, setTheme } = useTheme();
+  const { fontSize, options: fontOptions, setFontSize } = useChangeFont();
+
+  const formPerfil = useForm<PerfilFormData>({
+    resolver: zodResolver(perfilSchema),
+    defaultValues: {
+      full_name: initialData.fullName,
+    },
+  });
+
+  const formSenha = useForm<SenhaFormData>({
+    resolver: zodResolver(senhaSchema),
+    defaultValues: {
+      new_password: "",
+      confirm_password: "",
+      otp_code: "",
+    },
+  });
+
+  const watchedPassword = formSenha.watch("new_password");
+  const passwordStrength = React.useMemo(
+    () => getPasswordStrength(watchedPassword ?? ""),
+    [watchedPassword],
+  );
+
+  const onSubmitPerfil: SubmitHandler<PerfilFormData> = (data) => {
+    const formData = new FormData();
+    formData.append("full_name", data.full_name);
+
+    startTransition(() => formActionPerfil(formData));
+  };
+
+  const onSubmitSenha: SubmitHandler<SenhaFormData> = (data) => {
+    const formData = new FormData();
+    formData.append("new_password", data.new_password);
+    formData.append("confirm_password", data.confirm_password);
+    formData.append("otp_code", data.otp_code ?? "");
+
+    startTransition(() => formActionSenha(formData));
+  };
+
+  const handleAvatarPreview = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+
+      if (!file) {
+        setAvatarPreview(null);
+        return;
+      }
+
+      setAvatarPreview(URL.createObjectURL(file));
+    },
+    [],
+  );
+
+  React.useEffect(() => notifyStatus(statusPerfil), [statusPerfil]);
+  React.useEffect(() => notifyStatus(statusAvatar), [statusAvatar]);
+  React.useEffect(() => notifyStatus(statusSenha), [statusSenha]);
+
+  React.useEffect(() => {
+    if (statusSenha?.success) {
+      formSenha.reset();
+    }
+  }, [formSenha, statusSenha]);
+
+  React.useEffect(() => {
+    return () => {
+      if (avatarPreview) {
+        URL.revokeObjectURL(avatarPreview);
+      }
+    };
+  }, [avatarPreview]);
+
+  return {
+    formPerfil,
+    onSubmitPerfil,
+    statusPerfil,
+    isPendingPerfil,
+    statusAvatar,
+    avatarFormAction,
+    isPendingAvatar,
+    avatarPreview,
+    handleAvatarPreview,
+    formSenha,
+    onSubmitSenha,
+    statusSenha,
+    isPendingSenha,
+    passwordStrength,
+    theme,
+    setTheme,
+    fontSize,
+    fontOptions,
+    setFontSize,
+  };
+}
+
+export { usePerfilViewModel };
+export type { PerfilViewModel };

--- a/src/app/(cms)/cms/dashboard/perfil/loading.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+export default function Loading() {
+  return (
+    <section
+      className={cn(["space-y-6"])}
+      aria-label="Carregando perfil"
+      aria-busy="true"
+    >
+      <div className={cn(["space-y-2"])}>
+        <Skeleton className={cn(["h-8 w-48"])} />
+        <Skeleton className={cn(["h-4 w-full max-w-lg"])} />
+      </div>
+      <div className={cn(["grid gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]"])}>
+        <Skeleton className={cn(["h-96"])} />
+        <Skeleton className={cn(["h-80"])} />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/perfil/page.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { createClient } from "@/lib/supabase/server";
+import type { AdminProfile, AdminRole } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
+import { PerfilView } from "./_features/Perfil";
+import type { PerfilInitialData } from "./_features/Perfil/model";
+
+export const metadata: Metadata = {
+  title: "Meu perfil — NEXORA CMS",
+};
+
+const COOLDOWN_MS = 2 * 60 * 60 * 1000;
+
+type AuthMetadata = Record<string, unknown>;
+
+function getNextChangeAt(metadata: AuthMetadata, key: string) {
+  const value = metadata[key];
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const nextChangeAt = new Date(value).getTime() + COOLDOWN_MS;
+
+  if (Number.isNaN(nextChangeAt) || nextChangeAt <= Date.now()) {
+    return null;
+  }
+
+  return new Date(nextChangeAt).toISOString();
+}
+
+function PerfilLoading() {
+  return (
+    <section
+      className={cn(["space-y-6"])}
+      aria-label="Carregando perfil"
+      aria-busy="true"
+    >
+      <div className={cn(["space-y-2"])}>
+        <Skeleton className={cn(["h-8 w-48"])} />
+        <Skeleton className={cn(["h-4 w-full max-w-lg"])} />
+      </div>
+      <div className={cn(["grid gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]"])}>
+        <div className={cn(["space-y-6"])}>
+          <Skeleton className={cn(["h-64"])} />
+          <Skeleton className={cn(["h-56"])} />
+          <Skeleton className={cn(["h-72"])} />
+        </div>
+        <div className={cn(["space-y-6"])}>
+          <Skeleton className={cn(["h-80"])} />
+          <Skeleton className={cn(["h-48"])} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+async function PerfilData() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/cms/login");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .single<AdminProfile>();
+
+  const metadata = (user.user_metadata ?? {}) as AuthMetadata;
+  const initialData: PerfilInitialData = {
+    userId: user.id,
+    email: user.email ?? "",
+    fullName:
+      profile?.full_name ??
+      (typeof metadata.full_name === "string"
+        ? metadata.full_name
+        : "Administrador"),
+    role: (profile?.role ?? "admin") as AdminRole,
+    avatarUrl:
+      profile?.avatar_url ??
+      (typeof metadata.avatar_url === "string" ? metadata.avatar_url : null),
+    nextProfileChangeAt: getNextChangeAt(
+      metadata,
+      "cms_profile_last_changed_at",
+    ),
+    nextAvatarChangeAt: getNextChangeAt(metadata, "cms_avatar_last_changed_at"),
+    theme: "system",
+    fontSize: "md",
+  };
+
+  return <PerfilView initialData={initialData} />;
+}
+
+export default function PerfilPage() {
+  return (
+    <Suspense fallback={<PerfilLoading />}>
+      <PerfilData />
+    </Suspense>
+  );
+}

--- a/src/components/cms/CMSMobileSidebar.tsx
+++ b/src/components/cms/CMSMobileSidebar.tsx
@@ -1,51 +1,7 @@
 "use client";
 
-import { PanelLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
-import type { SessionUser } from "@/lib/supabase/types";
-import { cn } from "@/lib/utils";
-import { Sidebar } from "./Sidebar";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
-type Props = {
-  user: SessionUser;
-};
-
-export function CMSMobileSidebar({ user }: Props) {
-  return (
-    <Sheet>
-      <SheetTrigger
-        render={
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-lg"
-            className={cn("lg:hidden")}
-          />
-        }
-      >
-        <PanelLeft className={cn("size-5")} aria-hidden="true" />
-        <span className={cn("sr-only")}>Abrir menu do CMS</span>
-      </SheetTrigger>
-      <SheetContent
-        side="left"
-        className={cn("w-[min(20rem,calc(100vw-2rem))] max-w-none gap-0 p-0")}
-      >
-        <SheetTitle className={cn("sr-only")}>Menu do CMS</SheetTitle>
-        <SheetDescription className={cn("sr-only")}>
-          Navegação principal da área administrativa.
-        </SheetDescription>
-        <Sidebar
-          user={user}
-          className={cn("w-full border-r-0")}
-        />
-      </SheetContent>
-    </Sheet>
-  );
+export function CMSMobileSidebar() {
+  return <SidebarTrigger />;
 }

--- a/src/components/cms/CMSShell.tsx
+++ b/src/components/cms/CMSShell.tsx
@@ -1,9 +1,9 @@
+import { Sidebar as CMSAppSidebar } from "@/components/cms/Sidebar";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { SessionUser } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
-import { CMSMobileSidebar } from "./CMSMobileSidebar";
-import { Sidebar } from "./Sidebar";
 import { TopBar } from "./TopBar";
 
 type Props = {
@@ -14,20 +14,23 @@ type Props = {
 export function CMSShell({ user, children }: Props) {
   return (
     <TooltipProvider>
-      <div className={cn("flex h-screen overflow-hidden")}>
-        <Sidebar
-          user={user}
-          className={cn("sticky top-0 hidden h-screen lg:flex")}
-        />
-
-        <div className={cn("flex flex-1 flex-col overflow-hidden")}>
-          <TopBar mobileNav={<CMSMobileSidebar user={user} />} />
-
-          <main className={cn("flex-1 overflow-y-auto p-4 sm:p-6")}>
-            {children}
-          </main>
-        </div>
-      </div>
+      <SidebarProvider className={cn(["h-svh overflow-hidden"])}>
+        <CMSAppSidebar user={user} />
+        <SidebarInset>
+          <TopBar />
+          <div
+            className={cn([
+              "nexora-scrollbar min-h-0 flex-1 overflow-y-auto overflow-x-hidden",
+            ])}
+          >
+            <main
+              className={cn(["mx-auto min-w-0 w-full max-w-7xl p-4 sm:p-6"])}
+            >
+              {children}
+            </main>
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
       <Toaster richColors closeButton />
     </TooltipProvider>
   );

--- a/src/components/cms/Sidebar/SidebarNav.tsx
+++ b/src/components/cms/Sidebar/SidebarNav.tsx
@@ -6,9 +6,19 @@ import {
   FileText,
   LayoutDashboard,
   ShieldCheck,
+  UserCircle,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
@@ -37,6 +47,12 @@ const NAV_ITEMS = [
     icon: CalendarDays,
     exact: false,
   },
+  {
+    label: "Perfil",
+    href: "/cms/dashboard/perfil",
+    icon: UserCircle,
+    exact: false,
+  },
 ];
 
 type Props = {
@@ -45,40 +61,52 @@ type Props = {
 
 export function SidebarNav({ showLabels = true }: Props) {
   const pathname = usePathname();
+  const { state } = useSidebar();
+  const isCollapsed = state === "collapsed";
 
   return (
-    <nav className={cn("flex flex-col gap-1 px-2")}>
-      {NAV_ITEMS.map(({ label, href, icon: Icon, exact }) => {
-        const active = exact ? pathname === href : pathname.startsWith(href);
-        const link = (
-          <Link
-            key={href}
-            href={href}
-            className={cn(
-              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-              !showLabels && "justify-center px-0",
-              active
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-            )}
-            aria-label={ label}
-          >
-            <Icon className={cn("h-4 w-4 shrink-0")} />
-            <span>{label}</span>
-          </Link>
-        );
+    <SidebarGroup>
+      <SidebarGroupLabel>Administração</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {NAV_ITEMS.map(({ label, href, icon: Icon, exact }) => {
+            const active = exact
+              ? pathname === href
+              : pathname.startsWith(href);
+            const item = (
+              <SidebarMenuButton asChild isActive={active} title={label}>
+                <Link href={href} aria-current={active ? "page" : undefined}>
+                  <Icon className={cn(["size-4"])} aria-hidden="true" />
+                  {showLabels && (
+                    <span
+                      className={cn([
+                        "group-data-[state=collapsed]/sidebar:hidden",
+                      ])}
+                    >
+                      {label}
+                    </span>
+                  )}
+                </Link>
+              </SidebarMenuButton>
+            );
 
-        if (showLabels) return link;
-
-        return (
-          <Tooltip key={href}>
-            <TooltipTrigger render={<span className={cn("block")} />}>
-              {link}
-            </TooltipTrigger>
-            <TooltipContent side="right">{label}</TooltipContent>
-          </Tooltip>
-        );
-      })}
-    </nav>
+            return (
+              <SidebarMenuItem key={href}>
+                {isCollapsed ? (
+                  <Tooltip>
+                    <TooltipTrigger render={<span className={cn(["block"])} />}>
+                      {item}
+                    </TooltipTrigger>
+                    <TooltipContent side="right">{label}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  item
+                )}
+              </SidebarMenuItem>
+            );
+          })}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
   );
 }

--- a/src/components/cms/Sidebar/SidebarUserMenu.tsx
+++ b/src/components/cms/Sidebar/SidebarUserMenu.tsx
@@ -1,13 +1,35 @@
 "use client";
 
-import { LogOut, User } from "lucide-react";
-import Image from "next/image";
+import {
+  ChevronsUpDown,
+  LogOut,
+  Monitor,
+  Moon,
+  MoreHorizontal,
+  Settings,
+  Sun,
+  UserCircle,
+} from "lucide-react";
+import Link from "next/link";
 import { signOut } from "@/app/(cms)/cms/login/_features/login/actions";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useSidebar } from "@/components/ui/sidebar";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useChangeFont } from "@/hooks/useChangeFont";
+import { type ThemeMode, useTheme } from "@/hooks/useTheme";
 import type { SessionUser } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 
@@ -16,81 +38,246 @@ type Props = {
   compact?: boolean;
 };
 
-export function SidebarUserMenu({ user, compact = false }: Props) {
-  const userAvatar = (
-    <div
-      className={cn(
-        "flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground",
-      )}
-    >
-      {user.profile?.avatar_url ? (
-        <Image
-          src={user.profile.avatar_url}
-          alt={user.profile.full_name}
-          width={32}
-          height={32}
-          unoptimized
-          className={cn("h-8 w-8 rounded-full object-cover")}
-        />
-      ) : (
-        <User className={cn("h-4 w-4")} />
-      )}
-    </div>
+const THEME_ITEMS: Array<{
+  value: ThemeMode;
+  label: string;
+  icon: typeof Monitor;
+}> = [
+  { value: "system", label: "Sistema", icon: Monitor },
+  { value: "light", label: "Claro", icon: Sun },
+  { value: "dark", label: "Escuro", icon: Moon },
+];
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+}
+
+function UserAvatar({
+  avatarUrl,
+  displayName,
+  initials,
+  className,
+}: {
+  avatarUrl: string | null | undefined;
+  displayName: string;
+  initials: string;
+  className?: string;
+}) {
+  return (
+    <Avatar className={cn(["size-8", className])}>
+      {avatarUrl && <AvatarImage src={avatarUrl} alt={displayName} />}
+      <AvatarFallback
+        className={cn(["bg-primary text-xs text-primary-foreground"])}
+      >
+        {initials}
+      </AvatarFallback>
+    </Avatar>
   );
+}
 
-  const signOutButton = (
-    <button
-      type="submit"
-      className={cn(
-        "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
-        compact && "justify-center px-0",
-      )}
-      aria-label={compact ? "Sair" : undefined}
+export function SidebarUserMenu({ user }: Props) {
+  const { theme, setTheme } = useTheme();
+  const { fontSize, options, setFontSize } = useChangeFont();
+  const { isMobile, state } = useSidebar();
+  const displayName = user.profile?.full_name ?? "Administrador";
+  const avatarUrl = user.profile?.avatar_url;
+  const initials = getInitials(displayName) || "NX";
+  const isCollapsed = state === "collapsed";
+
+  if (isMobile) {
+    return (
+      <div className={cn(["space-y-2 px-2"])}>
+        <div
+          className={cn([
+            "flex items-center gap-3 rounded-md px-2 py-2 text-sm",
+          ])}
+        >
+          <UserAvatar
+            avatarUrl={avatarUrl}
+            displayName={displayName}
+            initials={initials}
+          />
+          <span className={cn(["min-w-0 flex-1 text-left"])}>
+            <span className={cn(["block truncate font-medium"])}>
+              {displayName}
+            </span>
+            <span
+              className={cn(["block truncate text-xs text-muted-foreground"])}
+            >
+              {user.email}
+            </span>
+          </span>
+        </div>
+        <Button
+          nativeButton={false}
+          variant="ghost"
+          className={cn(["w-full justify-start gap-2"])}
+          render={<Link href="/cms/dashboard/perfil" />}
+        >
+          <UserCircle className={cn(["size-4"])} />
+          Meu perfil
+        </Button>
+        <form action={signOut}>
+          <Button
+            type="submit"
+            variant="ghost"
+            className={cn([
+              "w-full justify-start gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive",
+            ])}
+          >
+            <LogOut className={cn(["size-4"])} />
+            Sair
+          </Button>
+        </form>
+      </div>
+    );
+  }
+
+  const trigger = (
+    <DropdownMenuTrigger
+      render={
+        <Button
+          type="button"
+          variant="ghost"
+          className={cn([
+            "relative h-auto w-full cursor-pointer justify-start gap-2 px-2 py-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[state=collapsed]/sidebar:size-9 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0",
+          ])}
+        />
+      }
     >
-      <LogOut className={cn("h-4 w-4 shrink-0")} />
-
-    </button>
+      <UserAvatar
+        avatarUrl={avatarUrl}
+        displayName={displayName}
+        initials={initials}
+      />
+      <span
+        className={cn([
+          "min-w-0 flex-1 text-left group-data-[state=collapsed]/sidebar:hidden",
+        ])}
+      >
+        <span className={cn(["block truncate text-sm font-medium"])}>
+          {displayName}
+        </span>
+        <span className={cn(["block truncate text-xs text-muted-foreground"])}>
+          {user.email}
+        </span>
+      </span>
+      <ChevronsUpDown
+        className={cn([
+          "ml-auto size-4 text-muted-foreground group-data-[state=collapsed]/sidebar:hidden",
+        ])}
+        aria-hidden="true"
+      />
+      <MoreHorizontal
+        className={cn([
+          "absolute right-0 bottom-0 hidden size-3 rounded-full bg-background text-primary group-data-[state=collapsed]/sidebar:block",
+        ])}
+        aria-hidden="true"
+      />
+    </DropdownMenuTrigger>
   );
 
   return (
-    <div className={cn("flex items-center justify-between px-4")}>
-      <div
-        className={cn(
-          "flex items-center gap-3 rounded-md px-3 py-2",
-        
-        )}
-      >
-    
-          <Tooltip>
-            <TooltipTrigger render={<span className={cn("block")} />}>
-              {userAvatar}
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              {user.profile?.full_name ?? user.email}
-            </TooltipContent>
-          </Tooltip>
-      
-       
-          <div className={cn("min-w-0 flex-1")}>
-            <p className={cn("truncate text-sm font-medium")}>
-              {user.profile?.full_name ?? "Administrador"}
-            </p>
-            <p className={cn("truncate text-xs text-muted-foreground")}>
-              {user.email}
-            </p>
+    <DropdownMenu>
+      {isCollapsed ? (
+        <Tooltip>
+          <TooltipTrigger render={<span className={cn(["block"])} />}>
+            {trigger}
+          </TooltipTrigger>
+          <TooltipContent side="right">Abrir menu do usuário</TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
+      <DropdownMenuContent side="right" align="end" className={cn(["w-64"])}>
+        <DropdownMenuLabel>
+          <div className={cn(["flex items-center gap-2"])}>
+            <UserAvatar
+              avatarUrl={avatarUrl}
+              displayName={displayName}
+              initials={initials}
+              className="size-9"
+            />
+            <div className={cn(["min-w-0"])}>
+              <p className={cn(["truncate"])}>{displayName}</p>
+              <p
+                className={cn([
+                  "truncate text-xs font-normal text-muted-foreground",
+                ])}
+              >
+                {user.email}
+              </p>
+            </div>
           </div>
-      
-      </div>
-
-      <form action={signOut}>
-  
-          <Tooltip>
-            <TooltipTrigger render={<span className={cn("block")} />}>
-              {signOutButton}
-            </TooltipTrigger>
-          </Tooltip>
-   
-      </form>
-    </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem closeOnClick={false}>
+          <Link
+            href="/cms/dashboard/perfil"
+            className={cn(["flex w-full items-center gap-2"])}
+          >
+            <UserCircle className={cn(["size-4"])} />
+            Meu perfil
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem closeOnClick={false}>
+          <Link
+            href="/cms/dashboard/perfil#preferencias"
+            className={cn(["flex w-full items-center gap-2"])}
+          >
+            <Settings className={cn(["size-4"])} />
+            Preferências
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className={cn(["text-xs text-muted-foreground"])}>
+          Tema
+        </DropdownMenuLabel>
+        {THEME_ITEMS.map(({ value, label, icon: Icon }) => (
+          <DropdownMenuItem key={value} onClick={() => setTheme(value)}>
+            <Icon className={cn(["size-4"])} />
+            <span className={cn(["flex-1"])}>{label}</span>
+            {theme === value && (
+              <span className={cn(["text-xs text-primary"])}>Atual</span>
+            )}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className={cn(["text-xs text-muted-foreground"])}>
+          Fonte
+        </DropdownMenuLabel>
+        {options.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onClick={() => setFontSize(option.value)}
+          >
+            <span className={cn(["flex-1"])}>{option.label}</span>
+            <span className={cn(["text-xs text-muted-foreground"])}>
+              {option.description}
+            </span>
+            {fontSize === option.value && (
+              <span className={cn(["text-xs text-primary"])}>Atual</span>
+            )}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <form action={signOut}>
+          <DropdownMenuItem variant="destructive" closeOnClick={false}>
+            <button
+              type="submit"
+              className={cn(["flex w-full items-center gap-2 text-left"])}
+            >
+              <LogOut className={cn(["size-4"])} />
+              Sair
+            </button>
+          </DropdownMenuItem>
+        </form>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/components/cms/Sidebar/index.tsx
+++ b/src/components/cms/Sidebar/index.tsx
@@ -19,6 +19,7 @@ import type { SessionUser } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import { SidebarNav } from "./SidebarNav";
 import { SidebarUserMenu } from "./SidebarUserMenu";
+import Link from "next/link";
 
 type Props = {
   user: SessionUser;
@@ -37,7 +38,7 @@ export function Sidebar({ user, className }: Props) {
                   asChild
                   className={cn(["h-10 font-bold tracking-widest"])}
                 >
-                  <a
+                  <Link
                     href="/cms/dashboard"
                     aria-label="Ir para o dashboard do CMS"
                   >
@@ -55,7 +56,7 @@ export function Sidebar({ user, className }: Props) {
                     >
                       NEXORA CMS
                     </span>
-                  </a>
+                  </Link>
                 </SidebarMenuButton>
               </TooltipTrigger>
               <TooltipContent side="right">Dashboard</TooltipContent>

--- a/src/components/cms/Sidebar/index.tsx
+++ b/src/components/cms/Sidebar/index.tsx
@@ -1,4 +1,20 @@
 import { Separator } from "@/components/ui/separator";
+import {
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  Sidebar as SidebarRoot,
+  SidebarSeparator,
+} from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { SessionUser } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import { SidebarNav } from "./SidebarNav";
@@ -6,39 +22,60 @@ import { SidebarUserMenu } from "./SidebarUserMenu";
 
 type Props = {
   user: SessionUser;
-
   className?: string;
 };
 
 export function Sidebar({ user, className }: Props) {
-
   return (
-    <aside
-      className={cn(
-        "flex h-full shrink-0 flex-col border-r bg-background",
-        "w-60",
-        className,
-      )}
-    >
-      <div
-        className={cn(
-          "flex h-14 items-center font-bold tracking-widest px-4",
-        )}
-      >
-        <span >NEXORA CMS</span>
-      </div>
+    <SidebarRoot collapsible="icon" className={className}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <Tooltip>
+              <TooltipTrigger render={<span className={cn(["block"])} />}>
+                <SidebarMenuButton
+                  asChild
+                  className={cn(["h-10 font-bold tracking-widest"])}
+                >
+                  <a
+                    href="/cms/dashboard"
+                    aria-label="Ir para o dashboard do CMS"
+                  >
+                    <span
+                      className={cn([
+                        "flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-xs font-black text-primary-foreground",
+                      ])}
+                    >
+                      N
+                    </span>
+                    <span
+                      className={cn([
+                        "truncate group-data-[state=collapsed]/sidebar:hidden",
+                      ])}
+                    >
+                      NEXORA CMS
+                    </span>
+                  </a>
+                </SidebarMenuButton>
+              </TooltipTrigger>
+              <TooltipContent side="right">Dashboard</TooltipContent>
+            </Tooltip>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
 
-      <Separator />
+      <SidebarSeparator />
 
-      <div className={cn("flex-1 overflow-y-auto py-4")}>
+      <SidebarContent>
         <SidebarNav />
-      </div>
+      </SidebarContent>
 
-      <Separator />
+      <Separator className={cn(["bg-sidebar-border"])} />
 
-      <div className={cn("py-4")}>
-        <SidebarUserMenu user={user}  />
-      </div>
-    </aside>
+      <SidebarFooter>
+        <SidebarUserMenu user={user} />
+      </SidebarFooter>
+      <SidebarRail />
+    </SidebarRoot>
   );
 }

--- a/src/components/cms/TopBar/index.tsx
+++ b/src/components/cms/TopBar/index.tsx
@@ -1,3 +1,4 @@
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -8,12 +9,15 @@ type Props = {
 export function TopBar({ title, mobileNav }: Props) {
   return (
     <header
-      className={cn(
-        "flex h-14 shrink-0 items-center gap-2 border-b bg-background px-3 sm:px-6",
-      )}
+      className={cn([
+        "sticky top-0 z-20 flex h-14 shrink-0 items-center gap-2 border-b bg-background/95 px-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:px-6",
+      ])}
     >
-      {mobileNav}
-      {title && <h1 className={cn("text-base font-semibold")}>{title}</h1>}
+      {mobileNav ?? <SidebarTrigger />}
+      {title && <h1 className={cn(["text-base font-semibold"])}>{title}</h1>}
+      <div className={cn(["ml-auto text-xs text-muted-foreground"])}>
+        NEXORA CMS
+      </div>
     </header>
   );
 }

--- a/src/components/layout/globals.css
+++ b/src/components/layout/globals.css
@@ -51,7 +51,7 @@
   --brand-primary: oklch(0.45 0.12 175);
   --brand-primary-dark: oklch(0.38 0.11 175);
   --brand-primary-light: oklch(0.96 0.04 175);
-  --brand-teal-hero: oklch(0.20 0.07 175);
+  --brand-teal-hero: oklch(0.2 0.07 175);
   --brand-accent: oklch(0.75 0.16 85);
   --brand-accent-dark: oklch(0.65 0.16 85);
   --brand-heading: oklch(0.13 0.02 240);
@@ -131,9 +131,36 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply overflow-x-hidden bg-background text-foreground;
   }
   html {
     @apply font-sans;
   }
+}
+
+.nexora-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--primary) 60%, transparent)
+    transparent;
+}
+
+.nexora-scrollbar::-webkit-scrollbar {
+  width: 0.625rem;
+  height: 0.625rem;
+}
+
+.nexora-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.nexora-scrollbar::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--primary) 35%, transparent);
+  border: 0.1875rem solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+.nexora-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--primary) 55%, transparent);
+  background-clip: padding-box;
 }

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+type AvatarProps = AvatarPrimitive.Root.Props & {
+  size?: "sm" | "default" | "lg";
+};
+
+const AVATAR_SIZE_CLASS: Record<NonNullable<AvatarProps["size"]>, string> = {
+  sm: "size-7",
+  default: "size-8",
+  lg: "size-12",
+};
+
+function Avatar({ className, size = "default", ...props }: AvatarProps) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn([
+        "relative flex shrink-0 overflow-hidden rounded-full",
+        AVATAR_SIZE_CLASS[size],
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(["aspect-square size-full object-cover", className])}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn([
+        "flex size-full items-center justify-center rounded-full bg-muted text-muted-foreground",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn([
+        "absolute right-0 bottom-0 flex size-3.5 items-center justify-center rounded-full border-2 border-background bg-primary text-primary-foreground shadow-sm",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarBadge, AvatarFallback, AvatarImage };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  className,
+  ...props
+}: MenuPrimitive.Trigger.Props) {
+  return (
+    <MenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      className={cn(["outline-none", className])}
+      {...props}
+    />
+  );
+}
+
+type DropdownMenuContentProps = MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "side" | "align" | "sideOffset" | "alignOffset"
+  >;
+
+function DropdownMenuContent({
+  className,
+  side = "bottom",
+  align = "end",
+  sideOffset = 8,
+  alignOffset,
+  ...props
+}: DropdownMenuContentProps) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
+        className={cn(["z-50"])}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn([
+            "min-w-44 rounded-lg border bg-popover p-1 text-popover-foreground shadow-md outline-none data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0",
+            className,
+          ])}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dropdown-menu-group"
+      className={cn(["p-1", className])}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dropdown-menu-label"
+      className={cn(["px-2 py-1.5 text-sm font-medium", className])}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn([
+        "relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        inset && "pl-8",
+        variant === "destructive" &&
+          "text-destructive data-highlighted:bg-destructive/10 data-highlighted:text-destructive",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      checked={checked}
+      className={cn([
+        "relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground",
+        className,
+      ])}
+      {...props}
+    >
+      <span
+        className={cn([
+          "absolute left-2 flex size-4 items-center justify-center",
+        ])}
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon className={cn(["size-4"])} />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.RadioItem.Props) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn([
+        "relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-accent data-highlighted:text-accent-foreground",
+        className,
+      ])}
+      {...props}
+    >
+      <span
+        className={cn([
+          "absolute left-2 flex size-4 items-center justify-center",
+        ])}
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CircleIcon className={cn(["size-2 fill-current"])} />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn(["-mx-1 my-1 h-px bg-border", className])}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn([
+        "flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground",
+        inset && "pl-8",
+        className,
+      ])}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className={cn(["ml-auto size-4"])} />
+    </MenuPrimitive.SubmenuTrigger>
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+};

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { OTPFieldPreview as OTPFieldPrimitive } from "@base-ui/react/otp-field";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function InputOTP({ className, ...props }: OTPFieldPrimitive.Root.Props) {
+  return (
+    <OTPFieldPrimitive.Root
+      data-slot="input-otp"
+      className={cn(["flex max-w-full items-center gap-2", className])}
+      {...props}
+    />
+  );
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn(["flex max-w-full items-center gap-2", className])}
+      {...props}
+    />
+  );
+}
+
+function InputOTPSlot({
+  className,
+  index,
+  ...props
+}: OTPFieldPrimitive.Input.Props & {
+  index: number;
+}) {
+  return (
+    <OTPFieldPrimitive.Input
+      data-slot="input-otp-slot"
+      data-slot-index={index}
+      className={cn([
+        "flex size-9 items-center justify-center rounded-lg border border-input bg-background text-center text-sm font-medium shadow-xs transition-all outline-none focus:border-ring focus:ring-3 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 sm:size-10",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
+import { cn } from "@/lib/utils";
+
+type ProgressProps = ProgressPrimitive.Root.Props & {
+  indicatorClassName?: string;
+};
+
+function Progress({
+  className,
+  indicatorClassName,
+  value,
+  ...props
+}: ProgressProps) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      value={value}
+      className={cn([
+        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+        className,
+      ])}
+      {...props}
+    >
+      <ProgressPrimitive.Track className={cn(["size-full"])}>
+        <ProgressPrimitive.Indicator
+          data-slot="progress-indicator"
+          className={cn([
+            "h-full w-full flex-1 bg-primary transition-transform",
+            indicatorClassName,
+          ])}
+          style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+        />
+      </ProgressPrimitive.Track>
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { PanelLeftIcon } from "lucide-react";
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3.5rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+type SidebarContextValue = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextValue | null>(null);
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 1023px)");
+    const handleChange = () => setIsMobile(mediaQuery.matches);
+
+    handleChange();
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return isMobile;
+}
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+
+  if (!context) {
+    throw new Error("useSidebar deve ser usado dentro de SidebarProvider.");
+  }
+
+  return context;
+}
+
+type SidebarProviderProps = React.ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange,
+  className,
+  style,
+  children,
+  ...props
+}: SidebarProviderProps) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+
+  const setOpen = React.useCallback(
+    (value: boolean) => {
+      if (onOpenChange) {
+        onOpenChange(value);
+        return;
+      }
+
+      _setOpen(value);
+    },
+    [onOpenChange],
+  );
+
+  const toggleSidebar = React.useCallback(() => {
+    if (isMobile) {
+      setOpenMobile((value) => !value);
+      return;
+    }
+
+    setOpen(!open);
+  }, [isMobile, open, setOpen]);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== SIDEBAR_KEYBOARD_SHORTCUT ||
+        (!event.metaKey && !event.ctrlKey)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      toggleSidebar();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  const state = open ? "expanded" : "collapsed";
+  const value = React.useMemo<SidebarContextValue>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      openMobile,
+      setOpenMobile,
+      isMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, openMobile, isMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={value}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            "--sidebar-width-mobile": SIDEBAR_WIDTH_MOBILE,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn([
+          "group/sidebar-wrapper flex h-svh w-full overflow-hidden bg-background",
+          className,
+        ])}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+type SidebarProps = React.ComponentProps<"aside"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+};
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: SidebarProps) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (isMobile) {
+    return (
+      <Sheet
+        open={openMobile}
+        onOpenChange={(nextOpen) => setOpenMobile(nextOpen)}
+      >
+        <SheetContent
+          side={side}
+          showCloseButton={false}
+          className={cn([
+            "w-[var(--sidebar-width-mobile)] max-w-[calc(100vw-2rem)] gap-0 border-sidebar-border bg-sidebar p-0 text-sidebar-foreground",
+            className,
+          ])}
+        >
+          <SheetTitle className={cn(["sr-only"])}>Menu do CMS</SheetTitle>
+          <SheetDescription className={cn(["sr-only"])}>
+            Navegação principal da área administrativa.
+          </SheetDescription>
+          <aside
+            data-slot="sidebar"
+            data-mobile="true"
+            className={cn(["flex h-full w-full flex-col"])}
+            {...props}
+          >
+            {children}
+          </aside>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  if (collapsible === "none") {
+    return (
+      <aside
+        data-slot="sidebar"
+        data-state={state}
+        data-variant={variant}
+        data-side={side}
+        className={cn([
+          "group/sidebar hidden h-svh w-[var(--sidebar-width)] shrink-0 flex-col overflow-hidden border-sidebar-border bg-sidebar text-sidebar-foreground lg:flex",
+          side === "left" ? "border-r" : "border-l",
+          className,
+        ])}
+        {...props}
+      >
+        {children}
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      data-slot="sidebar"
+      data-state={state}
+      data-variant={variant}
+      data-side={side}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      className={cn([
+        "group/sidebar hidden h-svh shrink-0 flex-col overflow-hidden border-sidebar-border bg-sidebar text-sidebar-foreground transition-[width] duration-200 ease-linear lg:flex",
+        side === "left" ? "border-r" : "border-l",
+        state === "collapsed" && collapsible === "icon"
+          ? "w-[var(--sidebar-width-icon)]"
+          : "w-[var(--sidebar-width)]",
+        variant === "floating" &&
+          "m-2 h-[calc(100svh-1rem)] rounded-xl border shadow-sm",
+        className,
+      ])}
+      {...props}
+    >
+      {children}
+    </aside>
+  );
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-lg"
+      className={cn(["text-muted-foreground", className])}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon className={cn(["size-5"])} />
+      <span className={cn(["sr-only"])}>Alternar menu lateral</span>
+    </Button>
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn([
+        "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      className={cn(["flex min-h-14 flex-col gap-2 p-2", className])}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      className={cn(["mt-auto flex flex-col gap-2 p-2", className])}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      className={cn([
+        "nexora-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden p-2 group-data-[state=collapsed]/sidebar:items-center group-data-[state=collapsed]/sidebar:px-2",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      className={cn([
+        "relative flex w-full min-w-0 flex-col p-2 group-data-[state=collapsed]/sidebar:w-auto group-data-[state=collapsed]/sidebar:p-0",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-label"
+      className={cn([
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none transition-[margin,opacity] duration-200 ease-linear group-data-[state=collapsed]/sidebar:hidden",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      className={cn([
+        "w-full text-sm group-data-[state=collapsed]/sidebar:w-auto",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      className={cn([
+        "flex w-full min-w-0 flex-col gap-1 group-data-[state=collapsed]/sidebar:w-auto group-data-[state=collapsed]/sidebar:items-center",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      className={cn(["group/menu-item relative", className])}
+      {...props}
+    />
+  );
+}
+
+type SidebarMenuButtonProps = React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+};
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  className,
+  children,
+  type = "button",
+  ...props
+}: SidebarMenuButtonProps) {
+  const classes = cn([
+    "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-data-[state=collapsed]/sidebar:size-9 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:gap-0 group-data-[state=collapsed]/sidebar:px-0 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+    isActive && "bg-sidebar-accent font-medium text-sidebar-accent-foreground",
+    className,
+  ]);
+
+  if (asChild && React.isValidElement(children)) {
+    const child = children as React.ReactElement<{
+      className?: string;
+      "data-active"?: boolean;
+    }>;
+
+    return React.cloneElement(child, {
+      className: cn([classes, child.props.className]),
+      "data-active": isActive,
+      ...props,
+    });
+  }
+
+  return (
+    <button
+      data-slot="sidebar-menu-button"
+      data-active={isActive}
+      type={type}
+      className={classes}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-separator"
+      className={cn(["mx-2 h-px bg-sidebar-border", className])}
+      {...props}
+    />
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-slot="sidebar-rail"
+      type="button"
+      aria-label="Alternar menu lateral"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      className={cn([
+        "absolute inset-y-0 right-0 z-20 hidden w-2 cursor-ew-resize transition-all after:absolute after:inset-y-0 after:left-1/2 after:w-px hover:after:bg-sidebar-border sm:flex",
+        className,
+      ])}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/src/databases/00004_cms_profile_preferences.sql
+++ b/src/databases/00004_cms_profile_preferences.sql
@@ -1,0 +1,85 @@
+-- ==============================================================================
+-- MIGRATION: 00004_cms_profile_preferences
+-- Objetivo: suporte incremental para perfil CMS, avatar e cooldown de alterações.
+-- Execute no Supabase SQL Editor após revisar nomes de bucket/políticas do projeto.
+-- ==============================================================================
+
+BEGIN;
+
+-- 1. Colunas opcionais para endurecer o cooldown no banco.
+-- A aplicação incremental usa Supabase Auth metadata para não quebrar ambientes
+-- antes desta migration. Estas colunas permitem auditoria e enforcement futuro.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS profile_last_changed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS avatar_last_changed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS password_last_changed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- 2. Bucket de avatars.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'avatars',
+  'avatars',
+  true,
+  5242880,
+  ARRAY['image/png', 'image/jpeg', 'image/webp']
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- 3. Políticas de Storage para administradores autenticados gerenciarem apenas
+-- o próprio diretório. O upload da aplicação usa service role no servidor, mas
+-- estas políticas deixam o bucket preparado para fluxos client-side futuros.
+DROP POLICY IF EXISTS "Admins podem ver avatars" ON storage.objects;
+CREATE POLICY "Admins podem ver avatars"
+  ON storage.objects
+  FOR SELECT
+  USING (bucket_id = 'avatars');
+
+DROP POLICY IF EXISTS "Admins podem inserir o próprio avatar" ON storage.objects;
+CREATE POLICY "Admins podem inserir o próprio avatar"
+  ON storage.objects
+  FOR INSERT
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND auth.role() = 'authenticated'
+    AND name LIKE ('admin-profiles/' || auth.uid() || '/%')
+  );
+
+DROP POLICY IF EXISTS "Admins podem atualizar o próprio avatar" ON storage.objects;
+CREATE POLICY "Admins podem atualizar o próprio avatar"
+  ON storage.objects
+  FOR UPDATE
+  USING (
+    bucket_id = 'avatars'
+    AND auth.role() = 'authenticated'
+    AND name LIKE ('admin-profiles/' || auth.uid() || '/%')
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND auth.role() = 'authenticated'
+    AND name LIKE ('admin-profiles/' || auth.uid() || '/%')
+  );
+
+DROP POLICY IF EXISTS "Admins podem remover o próprio avatar" ON storage.objects;
+CREATE POLICY "Admins podem remover o próprio avatar"
+  ON storage.objects
+  FOR DELETE
+  USING (
+    bucket_id = 'avatars'
+    AND auth.role() = 'authenticated'
+    AND name LIKE ('admin-profiles/' || auth.uid() || '/%')
+  );
+
+COMMIT;
+
+-- ==============================================================================
+-- Próxima etapa sugerida:
+-- - mover cooldown de Auth metadata para colunas profile_last_changed_at,
+--   avatar_last_changed_at e password_last_changed_at;
+-- - criar RPC SECURITY DEFINER para exclusão segura de conta própria;
+-- - conectar envio/verificação OTP por e-mail antes de liberar troca de senha.
+-- ==============================================================================

--- a/src/hooks/useChangeFont.ts
+++ b/src/hooks/useChangeFont.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+
+type FontSizeMode = "sm" | "md" | "lg" | "xl";
+
+type FontSizeOption = {
+  value: FontSizeMode;
+  label: string;
+  description: string;
+};
+
+const STORAGE_KEY = "nexora-font-size";
+
+const FONT_SIZE_OPTIONS: FontSizeOption[] = [
+  { value: "sm", label: "Compacta", description: "15px" },
+  { value: "md", label: "Padrão", description: "16px" },
+  { value: "lg", label: "Confortável", description: "17px" },
+  { value: "xl", label: "Ampliada", description: "18px" },
+];
+
+const FONT_SIZE_VALUE: Record<FontSizeMode, string> = {
+  sm: "15px",
+  md: "16px",
+  lg: "17px",
+  xl: "18px",
+};
+
+function isFontSizeMode(value: string | null): value is FontSizeMode {
+  return value === "sm" || value === "md" || value === "lg" || value === "xl";
+}
+
+function applyFontSize(value: FontSizeMode) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.style.fontSize = FONT_SIZE_VALUE[value];
+  document.documentElement.dataset.fontSize = value;
+}
+
+function useChangeFont() {
+  const [fontSize, setFontSizeState] = React.useState<FontSizeMode>("md");
+
+  React.useEffect(() => {
+    const storedValue = window.localStorage.getItem(STORAGE_KEY);
+    const initialValue = isFontSizeMode(storedValue) ? storedValue : "md";
+
+    setFontSizeState(initialValue);
+    applyFontSize(initialValue);
+  }, []);
+
+  const setFontSize = React.useCallback((nextFontSize: FontSizeMode) => {
+    setFontSizeState(nextFontSize);
+    window.localStorage.setItem(STORAGE_KEY, nextFontSize);
+    applyFontSize(nextFontSize);
+  }, []);
+
+  return {
+    fontSize,
+    options: FONT_SIZE_OPTIONS,
+    setFontSize,
+  };
+}
+
+export type { FontSizeMode, FontSizeOption };
+export { useChangeFont };

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+
+type ThemeMode = "system" | "light" | "dark";
+
+const STORAGE_KEY = "nexora-theme";
+
+function getSystemTheme() {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function applyTheme(theme: ThemeMode) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const resolvedTheme = theme === "system" ? getSystemTheme() : theme;
+  document.documentElement.classList.toggle("dark", resolvedTheme === "dark");
+  document.documentElement.dataset.theme = theme;
+}
+
+function useTheme() {
+  const [theme, setThemeState] = React.useState<ThemeMode>("system");
+
+  React.useEffect(() => {
+    const storedTheme = window.localStorage.getItem(
+      STORAGE_KEY,
+    ) as ThemeMode | null;
+    const initialTheme = storedTheme ?? "system";
+
+    setThemeState(initialTheme);
+    applyTheme(initialTheme);
+  }, []);
+
+  React.useEffect(() => {
+    applyTheme(theme);
+
+    if (theme !== "system") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => applyTheme("system");
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [theme]);
+
+  const setTheme = React.useCallback((nextTheme: ThemeMode) => {
+    setThemeState(nextTheme);
+    window.localStorage.setItem(STORAGE_KEY, nextTheme);
+    applyTheme(nextTheme);
+  }, []);
+
+  return {
+    theme,
+    setTheme,
+  };
+}
+
+export type { ThemeMode };
+export { useTheme };

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -10,18 +10,17 @@ type AdminProfile = {
 };
 
 type StudentProfile = {
-  id: string
-  full_name: string
-  email: string
-  avatar_url: string | null
-  created_at: string
-}
-
+  id: string;
+  full_name: string;
+  email: string;
+  avatar_url: string | null;
+  created_at: string;
+};
 
 type SessionUser = {
   id: string;
   email: string;
-  profile: AdminProfile;
+  profile: AdminProfile | null;
 };
 
 type ActionState =


### PR DESCRIPTION
## Resumo

- Adicionando a rota `/cms/dashboard/perfil` com estrutura MVVM para dados pessoais, avatar, preferências de tema/fonte e segurança.
- Migrando a sidebar do CMS para composição Shadcn-like, com dropdown de usuário, tooltips no modo minimizado e ajustes de responsividade.
- Ajustando responsividade do formulário de edição de evento e corrige scroll externo do shell CMS.
- Adicionando migration para preferências/avatar do perfil e registra a memória Synapos da entrega.

---

## Impacto

- Administradores passam a ter uma tela dedicada de perfil no CMS.
- A navegação lateral fica mais consistente em desktop, mobile e modo colapsado.
- O bloco do usuário no mobile evita abertura de dropdown que quebrava a sidebar.

---

## Referências

- #80
- #68
- #70

---

## Validação

- `./node_modules/.bin/biome check --write` nos arquivos alterados
- `npm run build`

---

## Observações

- A migration `src/databases/00004_cms_profile_preferences.sql` precisa ser aplicada no ambiente Supabase antes do teste real de avatar/storage.
- OTP real por e-mail e exclusão definitiva permanecem como próxima etapa segura registrada nas notas da sessão.