### PR TITLE
feat: analytics dashboard, listagem de alunos, edição de admins e bug fixes

### DIFF
--- a/src/app/(auth)/cadastro/_features/view.tsx
+++ b/src/app/(auth)/cadastro/_features/view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { PasswordInput } from "@/components/ui/password-input";
 import { cn } from "@/lib/utils"; // Ajuste conforme seu helper
 import { useCadastroViewModel } from "./viewModel";
 
@@ -75,14 +76,10 @@ export const CadastroView = () => {
             >
               Senha
             </label>
-            <input
+            <PasswordInput
               id="password"
               {...form.register("password")}
               name="password"
-              type="password"
-              className={cn(
-                "w-full rounded-md border border-slate-300 p-2 focus:border-teal-500 focus:ring-teal-500",
-              )}
             />
             {form.formState.errors.password && (
               <p className={cn("text-xs text-red-500")}>
@@ -98,14 +95,10 @@ export const CadastroView = () => {
             >
               Confirmar Senha
             </label>
-            <input
+            <PasswordInput
               id="confirm_password"
               {...form.register("confirm_password")}
               name="confirm_password"
-              type="password"
-              className={cn(
-                "w-full rounded-md border border-slate-300 p-2 focus:border-teal-500 focus:ring-teal-500",
-              )}
             />
             {form.formState.errors.confirm_password && (
               <p className={cn("text-xs text-red-500")}>

--- a/src/app/(auth)/login/_features/login/view.tsx
+++ b/src/app/(auth)/login/_features/login/view.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
 import { cn } from "@/lib/utils";
 import { useLoginViewModel } from "./viewModel";
 
@@ -58,9 +59,8 @@ export default function LoginView() {
               Esqueceu a senha?
             </Link>
           </div>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             disabled={isLoading}
             {...form.register("password")}
           />

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import LoginView from "./_features/login/view";
 
 export const metadata: Metadata = {
-  title: "Entrar - NEXORA",
+  title: "Entrar - NEXORA-TI",
 };
 
 export default function LoginPage() {

--- a/src/app/(cms)/cms/dashboard/_features/dashboard/view.tsx
+++ b/src/app/(cms)/cms/dashboard/_features/dashboard/view.tsx
@@ -1,12 +1,42 @@
-import { CalendarDays, ShieldCheck, Tv2 } from "lucide-react";
+import {
+  Activity,
+  CalendarDays,
+  GraduationCap,
+  MousePointerClick,
+  ShieldCheck,
+  TrendingUp,
+  Tv2,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+
+type TopRecurso = {
+  resource_type: string;
+  resource_slug: string | null;
+  access_count: number;
+  unique_students: number;
+};
 
 type Props = {
   totalEventos: number;
   eventosPublicados: number;
   totalAdmins: number;
+  totalAlunos: number;
+  totalAcessos: number;
+  acessosHoje: number;
+  acessosSemana: number;
+  alunosAtivos: number;
+  topRecursos: TopRecurso[];
+  acessosAutenticados: number;
 };
 
 type StatCard = {
@@ -17,12 +47,25 @@ type StatCard = {
   href: string;
 };
 
+const RESOURCE_TYPE_LABEL: Record<string, string> = {
+  course: "Curso",
+  event: "Evento",
+  page: "Página",
+};
+
 export function DashboardView({
   totalEventos,
   eventosPublicados,
   totalAdmins,
+  totalAlunos,
+  totalAcessos,
+  acessosHoje,
+  acessosSemana,
+  alunosAtivos,
+  topRecursos,
+  acessosAutenticados,
 }: Props) {
-  const cards: StatCard[] = [
+  const entityCards: StatCard[] = [
     {
       title: "Total de eventos",
       value: totalEventos,
@@ -44,6 +87,40 @@ export function DashboardView({
       icon: ShieldCheck,
       href: "/cms/dashboard/admins",
     },
+    {
+      title: "Alunos",
+      value: totalAlunos,
+      description: `cadastrado${totalAlunos !== 1 ? "s" : ""}`,
+      icon: GraduationCap,
+      href: "/cms/dashboard/alunos",
+    },
+  ];
+
+  const accessCards = [
+    {
+      title: "Total de acessos",
+      value: totalAcessos,
+      description: "desde o início",
+      icon: MousePointerClick,
+    },
+    {
+      title: "Acessos hoje",
+      value: acessosHoje,
+      description: "no dia atual",
+      icon: Activity,
+    },
+    {
+      title: "Acessos (7 dias)",
+      value: acessosSemana,
+      description: "últimos 7 dias",
+      icon: TrendingUp,
+    },
+    {
+      title: "Alunos ativos",
+      value: alunosAtivos,
+      description: "últimos 30 dias",
+      icon: Users,
+    },
   ];
 
   return (
@@ -53,12 +130,12 @@ export function DashboardView({
           Dashboard
         </h1>
         <p className={cn("text-muted-foreground mt-1")}>
-          Bem-vindo ao painel de administração do Portal Nexora.
+          Bem-vindo ao painel de administração do Portal NEXORA-TI.
         </p>
       </div>
 
-      <div className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-3")}>
-        {cards.map(({ title, value, description, icon: Icon, href }) => (
+      <div className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-4")}>
+        {entityCards.map(({ title, value, description, icon: Icon, href }) => (
           <Link key={title} href={href} className={cn("group")}>
             <Card className={cn("transition-shadow group-hover:shadow-md")}>
               <CardHeader
@@ -86,6 +163,200 @@ export function DashboardView({
           </Link>
         ))}
       </div>
+
+      <div className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-4")}>
+        {accessCards.map(({ title, value, description, icon: Icon }) => (
+          <Card key={title}>
+            <CardHeader
+              className={cn(
+                "flex flex-row items-center justify-between pb-2",
+              )}
+            >
+              <CardTitle
+                className={cn("text-sm font-medium text-muted-foreground")}
+              >
+                {title}
+              </CardTitle>
+              <Icon
+                className={cn("size-4 text-muted-foreground")}
+                aria-hidden="true"
+              />
+            </CardHeader>
+            <CardContent>
+              <p className={cn("text-2xl font-bold sm:text-3xl")}>{value}</p>
+              <p className={cn("text-xs text-muted-foreground mt-1")}>
+                {description}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className={cn("grid gap-6 lg:grid-cols-2")}>
+        <Card>
+          <CardHeader>
+            <CardTitle className={cn("flex items-center gap-2")}>
+              <MousePointerClick
+                className={cn("size-4 text-primary")}
+                aria-hidden="true"
+              />
+              Recursos mais acessados
+            </CardTitle>
+            <CardDescription>Top 10 por contagem de acessos.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {topRecursos.length === 0 ? (
+              <p
+                className={cn(
+                  "py-8 text-center text-sm text-muted-foreground",
+                )}
+              >
+                Nenhum acesso registrado ainda.
+              </p>
+            ) : (
+              <div className={cn("space-y-3")}>
+                {topRecursos.map((r) => {
+                  const maxCount = topRecursos[0]?.access_count ?? 1;
+                  const pct = Math.round((r.access_count / maxCount) * 100);
+                  return (
+                    <div
+                      key={`${r.resource_type}-${r.resource_slug}`}
+                      className={cn("space-y-1")}
+                    >
+                      <div
+                        className={cn(
+                          "flex items-center justify-between gap-2",
+                        )}
+                      >
+                        <div
+                          className={cn("flex min-w-0 items-center gap-2")}
+                        >
+                          <Badge variant="outline" className={cn("shrink-0")}>
+                            {RESOURCE_TYPE_LABEL[r.resource_type] ??
+                              r.resource_type}
+                          </Badge>
+                          <span className={cn("truncate text-sm font-medium")}>
+                            {r.resource_slug ?? "—"}
+                          </span>
+                        </div>
+                        <span
+                          className={cn(
+                            "shrink-0 text-sm font-bold tabular-nums",
+                          )}
+                        >
+                          {r.access_count}
+                        </span>
+                      </div>
+                      <div
+                        className={cn(
+                          "h-1.5 w-full overflow-hidden rounded-full bg-muted",
+                        )}
+                      >
+                        <div
+                          className={cn("h-full rounded-full bg-primary")}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <p className={cn("text-xs text-muted-foreground")}>
+                        {r.unique_students} aluno
+                        {r.unique_students !== 1 ? "s" : ""} únicos
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <AcessosPieCard
+          totalAcessos={totalAcessos}
+          acessosAutenticados={acessosAutenticados}
+        />
+      </div>
     </div>
+  );
+}
+
+type PieCardProps = {
+  totalAcessos: number;
+  acessosAutenticados: number;
+};
+
+function AcessosPieCard({ totalAcessos, acessosAutenticados }: PieCardProps) {
+  const anonimos = totalAcessos - acessosAutenticados;
+  const pctAuth =
+    totalAcessos > 0 ? Math.round((acessosAutenticados / totalAcessos) * 100) : 0;
+  const pctAnon = 100 - pctAuth;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className={cn("flex items-center gap-2")}>
+          <Users className={cn("size-4 text-primary")} aria-hidden="true" />
+          Alunos vs. Anônimos
+        </CardTitle>
+        <CardDescription>
+          Distribuição de acessos por tipo de visitante.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className={cn("flex flex-col items-center gap-6 pt-2")}>
+        {totalAcessos === 0 ? (
+          <p className={cn("py-8 text-center text-sm text-muted-foreground")}>
+            Nenhum acesso registrado ainda.
+          </p>
+        ) : (
+          <>
+            <div
+              className={cn("relative size-36 rounded-full")}
+              style={{
+                background: `conic-gradient(var(--primary) ${pctAuth}%, var(--muted-foreground) ${pctAuth}%)`,
+              }}
+              role="img"
+              aria-label={`${pctAuth}% alunos, ${pctAnon}% anônimos`}
+            >
+              <div
+                className={cn(
+                  "absolute inset-[27%] rounded-full bg-card",
+                )}
+              />
+            </div>
+
+            <dl className={cn("w-full space-y-2")}>
+              <div className={cn("flex items-center justify-between gap-2")}>
+                <dt className={cn("flex items-center gap-2 text-sm")}>
+                  <span
+                    className={cn("inline-block size-3 rounded-full bg-primary")}
+                  />
+                  Alunos
+                </dt>
+                <dd className={cn("text-sm font-bold tabular-nums")}>
+                  {acessosAutenticados}{" "}
+                  <span className={cn("font-normal text-muted-foreground")}>
+                    ({pctAuth}%)
+                  </span>
+                </dd>
+              </div>
+              <div className={cn("flex items-center justify-between gap-2")}>
+                <dt className={cn("flex items-center gap-2 text-sm")}>
+                  <span
+                    className={cn(
+                      "inline-block size-3 rounded-full bg-muted-foreground",
+                    )}
+                  />
+                  Anônimos
+                </dt>
+                <dd className={cn("text-sm font-bold tabular-nums")}>
+                  {anonimos}{" "}
+                  <span className={cn("font-normal text-muted-foreground")}>
+                    ({pctAnon}%)
+                  </span>
+                </dd>
+              </div>
+            </dl>
+          </>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/EditAdminDrawer.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/EditAdminDrawer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useActionState, useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import type { ActionState, AdminProfile } from "@/lib/supabase/types";
+import { cn } from "@/lib/utils";
+import { editarAdmin } from "./editAdminActions";
+import { type EditAdminFormData, editAdminSchema } from "./editAdminSchema";
+
+const ROLE_OPTIONS = [
+  { value: "content_creator", label: "Content Creator" },
+  { value: "professor", label: "Professor" },
+  { value: "admin", label: "Admin" },
+] as const;
+
+type Props = {
+  admin: AdminProfile | null;
+  onClose: () => void;
+};
+
+export function EditAdminDrawer({ admin, onClose }: Props) {
+  const boundAction = editarAdmin.bind(null, admin?.id ?? "");
+
+  const [state, formAction, isPending] = useActionState<ActionState, FormData>(
+    boundAction,
+    undefined,
+  );
+
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useForm<EditAdminFormData>({
+    resolver: zodResolver(editAdminSchema),
+    defaultValues: {
+      full_name: admin?.full_name ?? "",
+      role: (admin?.role as EditAdminFormData["role"]) ?? "content_creator",
+    },
+  });
+
+  useEffect(() => {
+    if (state?.success) onClose();
+  }, [state, onClose]);
+
+  return (
+    <Sheet
+      open={admin !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Editar administrador</SheetTitle>
+          <SheetDescription>
+            Atualize os dados de {admin?.full_name ?? "administrador"}.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form action={formAction} className={cn("flex flex-col gap-5 px-4 py-2")}>
+          <div className={cn("space-y-1.5")}>
+            <Label htmlFor="edit_full_name">Nome completo</Label>
+            <Input
+              id="edit_full_name"
+              type="text"
+              {...register("full_name")}
+              name="full_name"
+              className={cn({
+                "border-destructive":
+                  errors.full_name || state?.errors?.full_name,
+              })}
+            />
+            {(errors.full_name || state?.errors?.full_name) && (
+              <p className={cn("text-xs text-destructive")}>
+                {errors.full_name?.message ?? state?.errors?.full_name?.[0]}
+              </p>
+            )}
+          </div>
+
+          <div className={cn("space-y-1.5")}>
+            <Label htmlFor="edit_role">Permissão</Label>
+            <Controller
+              control={control}
+              name="role"
+              render={({ field }) => (
+                <>
+                  <input type="hidden" name="role" value={field.value} />
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger id="edit_role">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </>
+              )}
+            />
+            {(errors.role || state?.errors?.role) && (
+              <p className={cn("text-xs text-destructive")}>
+                {errors.role?.message ?? state?.errors?.role?.[0]}
+              </p>
+            )}
+          </div>
+
+          {state?.message && !state.success && (
+            <p className={cn("text-sm text-destructive")}>{state.message}</p>
+          )}
+
+          <SheetFooter>
+            <Button type="submit" disabled={isPending} className={cn("w-full")}>
+              {isPending ? "Salvando..." : "Salvar alterações"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              className={cn("w-full")}
+            >
+              Cancelar
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/editAdminActions.ts
+++ b/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/editAdminActions.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { ActionState } from "@/lib/supabase/types";
+import { editAdminSchema } from "./editAdminSchema";
+
+export async function editarAdmin(
+  id: string,
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const raw = {
+    full_name: formData.get("full_name"),
+    role: formData.get("role"),
+  };
+
+  const parsed = editAdminSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      errors: parsed.error.flatten((issue) => issue.message)
+        .fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient
+    .from("profiles")
+    .update({ full_name: parsed.data.full_name, role: parsed.data.role })
+    .eq("id", id);
+
+  if (error) {
+    return { message: "Erro ao atualizar administrador. Tente novamente." };
+  }
+
+  revalidatePath("/cms/dashboard/admins");
+  return { success: true, message: "Administrador atualizado com sucesso." };
+}

--- a/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/editAdminSchema.ts
+++ b/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/editAdminSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const editAdminSchema = z.object({
+  full_name: z.string().min(2, "Nome deve ter no mínimo 2 caracteres"),
+  role: z.enum(["admin", "content_creator", "professor"]),
+});
+
+export type EditAdminFormData = z.infer<typeof editAdminSchema>;

--- a/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/view.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/_features/AdminsList/view.tsx
@@ -1,8 +1,13 @@
+"use client";
+
+import { Pencil } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { AdminProfile, AdminRole } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
+import { EditAdminDrawer } from "./EditAdminDrawer";
 
 type Props = {
   admins: AdminProfile[];
@@ -31,6 +36,8 @@ function formatDate(iso: string) {
 }
 
 export function AdminsListView({ admins }: Props) {
+  const [editingAdmin, setEditingAdmin] = useState<AdminProfile | null>(null);
+
   return (
     <div className={cn("space-y-6")}>
       <div
@@ -80,9 +87,19 @@ export function AdminsListView({ admins }: Props) {
                       Desde {formatDate(admin.created_at)}
                     </p>
                   </div>
-                  <Badge variant={ROLE_VARIANT[admin.role]}>
-                    {ROLE_LABEL[admin.role]}
-                  </Badge>
+                  <div className={cn("flex shrink-0 items-center gap-2")}>
+                    <Badge variant={ROLE_VARIANT[admin.role]}>
+                      {ROLE_LABEL[admin.role]}
+                    </Badge>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => setEditingAdmin(admin)}
+                      aria-label={`Editar ${admin.full_name}`}
+                    >
+                      <Pencil className={cn("size-3.5")} />
+                    </Button>
+                  </div>
                 </div>
               </article>
             ))}
@@ -115,6 +132,13 @@ export function AdminsListView({ admins }: Props) {
                   >
                     Desde
                   </th>
+                  <th
+                    className={cn(
+                      "px-4 py-3 text-right font-medium text-muted-foreground",
+                    )}
+                  >
+                    Ações
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -136,6 +160,17 @@ export function AdminsListView({ admins }: Props) {
                     <td className={cn("px-4 py-3 text-muted-foreground")}>
                       {formatDate(admin.created_at)}
                     </td>
+                    <td className={cn("px-4 py-3 text-right")}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingAdmin(admin)}
+                        aria-label={`Editar ${admin.full_name}`}
+                      >
+                        <Pencil className={cn("size-3.5")} />
+                        Editar
+                      </Button>
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -143,6 +178,12 @@ export function AdminsListView({ admins }: Props) {
           </div>
         </>
       )}
+
+      <EditAdminDrawer
+        key={editingAdmin?.id ?? "none"}
+        admin={editingAdmin}
+        onClose={() => setEditingAdmin(null)}
+      />
     </div>
   );
 }

--- a/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/actions.ts
+++ b/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/actions.ts
@@ -33,6 +33,7 @@ export async function criarAdmin(
       email: parsed.data.email,
       password: parsed.data.password,
       email_confirm: true,
+      user_metadata: { is_cms_admin: true },
     });
 
   if (authError || !authData.user) {

--- a/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/view.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/novo/_features/NovoAdmin/view.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { Controller } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { useNovoAdminViewModel } from "./viewModel";
 
@@ -17,6 +26,7 @@ export function NovoAdminView() {
     useNovoAdminViewModel();
   const {
     register,
+    control,
     formState: { errors },
   } = form;
 
@@ -73,9 +83,8 @@ export function NovoAdminView() {
 
         <div className={cn(["space-y-1.5"])}>
           <Label htmlFor="password">Senha temporária</Label>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             placeholder="••••••••"
             autoComplete="new-password"
             {...register("password")}
@@ -95,9 +104,8 @@ export function NovoAdminView() {
 
         <div className={cn(["space-y-1.5"])}>
           <Label htmlFor="confirm_password">Confirmar senha</Label>
-          <Input
+          <PasswordInput
             id="confirm_password"
-            type="password"
             placeholder="••••••••"
             autoComplete="new-password"
             {...register("confirm_password")}
@@ -118,21 +126,32 @@ export function NovoAdminView() {
 
         <div className={cn(["space-y-1.5"])}>
           <Label htmlFor="role">Permissão</Label>
-          <select
-            id="role"
-            {...register("role")}
-            className={cn([
-              "h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              { "border-destructive": errors.role || state?.errors?.role },
-            ])}
-          >
-            {ROLE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+          <Controller
+            control={control}
+            name="role"
+            render={({ field }) => (
+              <>
+                <input type="hidden" name="role" value={field.value} />
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger
+                    id="role"
+                    className={cn([
+                      { "border-destructive": errors.role || state?.errors?.role },
+                    ])}
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ROLE_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </>
+            )}
+          />
           {(errors.role || state?.errors?.role) && (
             <p className={cn(["text-xs text-destructive"])}>
               {errors.role?.message ?? state?.errors?.role?.[0]}

--- a/src/app/(cms)/cms/dashboard/admins/novo/page.tsx
+++ b/src/app/(cms)/cms/dashboard/admins/novo/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { NovoAdminView } from "./_features/NovoAdmin/view";
 
 export const metadata: Metadata = {
-  title: "Novo Administrador — NEXORA CMS",
+  title: "Novo Administrador — NEXORA-TI CMS",
 };
 
 export default function NovoAdminPage() {

--- a/src/app/(cms)/cms/dashboard/alunos/_features/AlunosList/view.tsx
+++ b/src/app/(cms)/cms/dashboard/alunos/_features/AlunosList/view.tsx
@@ -1,0 +1,132 @@
+import { cn } from "@/lib/utils";
+
+type StudentRow = {
+  id: string;
+  full_name: string;
+  email: string;
+  avatar_url: string | null;
+  created_at: string;
+};
+
+type Props = {
+  alunos: StudentRow[];
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+export function AlunosListView({ alunos }: Props) {
+  return (
+    <div className={cn("space-y-6")}>
+      <div
+        className={cn(
+          "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+        )}
+      >
+        <div>
+          <h2 className={cn("text-xl font-bold tracking-tight sm:text-2xl")}>
+            Alunos
+          </h2>
+          <p className={cn("text-sm text-muted-foreground")}>
+            {alunos.length} aluno{alunos.length !== 1 ? "s" : ""} cadastrado
+            {alunos.length !== 1 ? "s" : ""}.
+          </p>
+        </div>
+      </div>
+
+      {alunos.length === 0 ? (
+        <div
+          className={cn(
+            "rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground sm:p-12",
+          )}
+        >
+          Nenhum aluno cadastrado ainda.
+        </div>
+      ) : (
+        <>
+          <div className={cn("grid gap-3 sm:hidden")}>
+            {alunos.map((aluno) => (
+              <article
+                key={aluno.id}
+                className={cn("rounded-lg border bg-background p-4")}
+              >
+                <div className={cn("min-w-0")}>
+                  <h3 className={cn("truncate text-sm font-medium")}>
+                    {aluno.full_name}
+                  </h3>
+                  <p
+                    className={cn(
+                      "mt-1 truncate text-xs text-muted-foreground",
+                    )}
+                  >
+                    {aluno.email}
+                  </p>
+                  <p className={cn("mt-1 text-xs text-muted-foreground")}>
+                    Desde {formatDate(aluno.created_at)}
+                  </p>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div
+            className={cn("hidden overflow-x-auto rounded-lg border sm:block")}
+          >
+            <table className={cn("w-full min-w-[40rem] text-sm")}>
+              <thead>
+                <tr className={cn("border-b bg-muted/50")}>
+                  <th
+                    className={cn(
+                      "px-4 py-3 text-left font-medium text-muted-foreground",
+                    )}
+                  >
+                    Nome
+                  </th>
+                  <th
+                    className={cn(
+                      "px-4 py-3 text-left font-medium text-muted-foreground",
+                    )}
+                  >
+                    E-mail
+                  </th>
+                  <th
+                    className={cn(
+                      "px-4 py-3 text-left font-medium text-muted-foreground",
+                    )}
+                  >
+                    Desde
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {alunos.map((aluno, index) => (
+                  <tr
+                    key={aluno.id}
+                    className={cn("border-b last:border-0", {
+                      "bg-muted/20": index % 2 !== 0,
+                    })}
+                  >
+                    <td className={cn("px-4 py-3 font-medium")}>
+                      {aluno.full_name}
+                    </td>
+                    <td className={cn("px-4 py-3 text-muted-foreground")}>
+                      {aluno.email}
+                    </td>
+                    <td className={cn("px-4 py-3 text-muted-foreground")}>
+                      {formatDate(aluno.created_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/alunos/page.tsx
+++ b/src/app/(cms)/cms/dashboard/alunos/page.tsx
@@ -1,33 +1,30 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { createClient } from "@/lib/supabase/server";
-import type { AdminProfile } from "@/lib/supabase/types";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { cn } from "@/lib/utils";
-import { AdminsListView } from "./_features/AdminsList/view";
+import { AlunosListView } from "./_features/AlunosList/view";
 
 export const metadata: Metadata = {
-  title: "Administradores — NEXORA-TI CMS",
+  title: "Alunos — NEXORA-TI CMS",
 };
 
-async function AdminsData() {
-  const supabase = await createClient();
+async function AlunosData() {
+  const adminClient = createAdminClient();
 
-  const { data } = await supabase
-    .from("profiles")
-    .select("*")
+  const { data } = await adminClient
+    .from("student_profiles")
+    .select("id, full_name, email, avatar_url, created_at")
     .order("created_at", { ascending: false });
 
-  const admins: AdminProfile[] = data ?? [];
-
-  return <AdminsListView admins={admins} />;
+  return <AlunosListView alunos={data ?? []} />;
 }
 
-function AdminsLoading() {
+function AlunosLoading() {
   return (
     <section
       className={cn("space-y-6")}
-      aria-label="Carregando administradores"
+      aria-label="Carregando alunos"
       aria-busy="true"
     >
       <div
@@ -39,7 +36,6 @@ function AdminsLoading() {
           <Skeleton className={cn("h-7 w-48")} />
           <Skeleton className={cn("h-4 w-72 max-w-full")} />
         </div>
-        <Skeleton className={cn("h-9 w-full sm:w-40")} />
       </div>
       <div className={cn("grid gap-3 sm:hidden")}>
         <Skeleton className={cn("h-24")} />
@@ -55,10 +51,10 @@ function AdminsLoading() {
   );
 }
 
-export default function AdminsPage() {
+export default function AlunosPage() {
   return (
-    <Suspense fallback={<AdminsLoading />}>
-      <AdminsData />
+    <Suspense fallback={<AlunosLoading />}>
+      <AlunosData />
     </Suspense>
   );
 }

--- a/src/app/(cms)/cms/dashboard/eventos/[id]/page.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/[id]/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata({
 
   return {
     title: data
-      ? `Editar: ${data.title} — NEXORA CMS`
-      : "Editar Evento — NEXORA CMS",
+      ? `Editar: ${data.title} — NEXORA-TI CMS`
+      : "Editar Evento — NEXORA-TI CMS",
   };
 }
 

--- a/src/app/(cms)/cms/dashboard/eventos/novo/page.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/novo/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { NovoEventoView } from "./_features/NovoEvento/view";
 
 export const metadata: Metadata = {
-  title: "Novo Evento — NEXORA CMS",
+  title: "Novo Evento — NEXORA-TI CMS",
 };
 
 export default function NovoEventoPage() {

--- a/src/app/(cms)/cms/dashboard/eventos/page.tsx
+++ b/src/app/(cms)/cms/dashboard/eventos/page.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { EventosListView } from "./_features/EventosList/view";
 
 export const metadata: Metadata = {
-  title: "Eventos — NEXORA CMS",
+  title: "Eventos — NEXORA-TI CMS",
 };
 
 type PageProps = {

--- a/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/view.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/_features/Perfil/view.tsx
@@ -37,6 +37,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp";
 import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/utils/getInitials";
 import type { PerfilInitialData } from "./model";
@@ -246,9 +247,8 @@ export function PerfilView({ initialData }: Props) {
                 <div className={cn(["grid min-w-0 gap-4 lg:grid-cols-2"])}>
                   <div className={cn(["min-w-0 space-y-2"])}>
                     <Label htmlFor="new_password">Nova senha</Label>
-                    <Input
+                    <PasswordInput
                       id="new_password"
-                      type="password"
                       autoComplete="new-password"
                       disabled={isPendingSenha}
                       {...formSenha.register("new_password")}
@@ -261,9 +261,8 @@ export function PerfilView({ initialData }: Props) {
                   </div>
                   <div className={cn(["min-w-0 space-y-2"])}>
                     <Label htmlFor="confirm_password">Confirmar senha</Label>
-                    <Input
+                    <PasswordInput
                       id="confirm_password"
-                      type="password"
                       autoComplete="new-password"
                       disabled={isPendingSenha}
                       {...formSenha.register("confirm_password")}

--- a/src/app/(cms)/cms/dashboard/perfil/page.tsx
+++ b/src/app/(cms)/cms/dashboard/perfil/page.tsx
@@ -9,7 +9,7 @@ import { PerfilView } from "./_features/Perfil";
 import type { PerfilInitialData } from "./_features/Perfil/model";
 
 export const metadata: Metadata = {
-  title: "Meu perfil — NEXORA CMS",
+  title: "Meu perfil — NEXORA-TI CMS",
 };
 
 const DAILY_CHANGE_LIMIT = 5;

--- a/src/app/(cms)/cms/dashboard/relatorios/_features/Relatorios/view.tsx
+++ b/src/app/(cms)/cms/dashboard/relatorios/_features/Relatorios/view.tsx
@@ -1,0 +1,286 @@
+import {
+  Activity,
+  CalendarDays,
+  GraduationCap,
+  MousePointerClick,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type TopRecurso = {
+  resource_type: string;
+  resource_slug: string | null;
+  access_count: number;
+  unique_students: number;
+};
+
+type Props = {
+  totalAcessos: number;
+  acessosHoje: number;
+  acessosSemana: number;
+  alunosAtivos: number;
+  topRecursos: TopRecurso[];
+  eventosPorStatus: Record<string, number>;
+  totalMatriculas: number;
+};
+
+const RESOURCE_TYPE_LABEL: Record<string, string> = {
+  course: "Curso",
+  event: "Evento",
+  page: "Página",
+};
+
+const EVENT_STATUS_LABEL: Record<string, string> = {
+  draft: "Rascunho",
+  published: "Publicado",
+  archived: "Arquivado",
+};
+
+const EVENT_STATUS_VARIANT: Record<
+  string,
+  "default" | "secondary" | "outline"
+> = {
+  draft: "outline",
+  published: "default",
+  archived: "secondary",
+};
+
+export function RelatoriosView({
+  totalAcessos,
+  acessosHoje,
+  acessosSemana,
+  alunosAtivos,
+  topRecursos,
+  eventosPorStatus,
+  totalMatriculas,
+}: Props) {
+  const summaryCards = [
+    {
+      title: "Total de acessos",
+      value: totalAcessos,
+      description: "desde o início",
+      icon: MousePointerClick,
+    },
+    {
+      title: "Acessos hoje",
+      value: acessosHoje,
+      description: "no dia atual",
+      icon: Activity,
+    },
+    {
+      title: "Acessos (7 dias)",
+      value: acessosSemana,
+      description: "últimos 7 dias",
+      icon: TrendingUp,
+    },
+    {
+      title: "Alunos ativos",
+      value: alunosAtivos,
+      description: "últimos 30 dias",
+      icon: Users,
+    },
+  ];
+
+  return (
+    <div className={cn("space-y-6")}>
+      <div>
+        <h2 className={cn("text-xl font-bold tracking-tight sm:text-2xl")}>
+          Relatórios
+        </h2>
+        <p className={cn("mt-1 text-sm text-muted-foreground")}>
+          Métricas de acesso, engajamento e conteúdo do portal.
+        </p>
+      </div>
+
+      {/* Summary cards */}
+      <div className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-4")}>
+        {summaryCards.map(({ title, value, description, icon: Icon }) => (
+          <Card key={title}>
+            <CardHeader
+              className={cn(
+                "flex flex-row items-center justify-between pb-2",
+              )}
+            >
+              <CardTitle
+                className={cn("text-sm font-medium text-muted-foreground")}
+              >
+                {title}
+              </CardTitle>
+              <Icon
+                className={cn("size-4 text-muted-foreground")}
+                aria-hidden="true"
+              />
+            </CardHeader>
+            <CardContent>
+              <p className={cn("text-2xl font-bold sm:text-3xl")}>{value}</p>
+              <p className={cn("mt-1 text-xs text-muted-foreground")}>
+                {description}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className={cn("grid gap-6 lg:grid-cols-2")}>
+        {/* Top recursos acessados */}
+        <Card>
+          <CardHeader>
+            <CardTitle className={cn("flex items-center gap-2")}>
+              <MousePointerClick
+                className={cn("size-4 text-primary")}
+                aria-hidden="true"
+              />
+              Recursos mais acessados
+            </CardTitle>
+            <CardDescription>
+              Top 10 por contagem de acessos únicos.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {topRecursos.length === 0 ? (
+              <p
+                className={cn(
+                  "py-8 text-center text-sm text-muted-foreground",
+                )}
+              >
+                Nenhum acesso registrado ainda.
+              </p>
+            ) : (
+              <div className={cn("space-y-3")}>
+                {topRecursos.map((r, index) => {
+                  const maxCount = topRecursos[0]?.access_count ?? 1;
+                  const pct = Math.round((r.access_count / maxCount) * 100);
+                  return (
+                    <div key={index} className={cn("space-y-1")}>
+                      <div
+                        className={cn("flex items-center justify-between gap-2")}
+                      >
+                        <div
+                          className={cn(
+                            "flex min-w-0 items-center gap-2",
+                          )}
+                        >
+                          <Badge variant="outline" className={cn("shrink-0")}>
+                            {RESOURCE_TYPE_LABEL[r.resource_type] ??
+                              r.resource_type}
+                          </Badge>
+                          <span
+                            className={cn(
+                              "truncate text-sm font-medium",
+                            )}
+                          >
+                            {r.resource_slug ?? "—"}
+                          </span>
+                        </div>
+                        <span
+                          className={cn(
+                            "shrink-0 text-sm font-bold tabular-nums",
+                          )}
+                        >
+                          {r.access_count}
+                        </span>
+                      </div>
+                      <div
+                        className={cn(
+                          "h-1.5 w-full overflow-hidden rounded-full bg-muted",
+                        )}
+                      >
+                        <div
+                          className={cn("h-full rounded-full bg-primary")}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <p className={cn("text-xs text-muted-foreground")}>
+                        {r.unique_students} aluno
+                        {r.unique_students !== 1 ? "s" : ""} únicos
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className={cn("space-y-6")}>
+          {/* Eventos por status */}
+          <Card>
+            <CardHeader>
+              <CardTitle className={cn("flex items-center gap-2")}>
+                <CalendarDays
+                  className={cn("size-4 text-primary")}
+                  aria-hidden="true"
+                />
+                Eventos por status
+              </CardTitle>
+              <CardDescription>Distribuição atual do catálogo.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {Object.keys(eventosPorStatus).length === 0 ? (
+                <p
+                  className={cn(
+                    "py-6 text-center text-sm text-muted-foreground",
+                  )}
+                >
+                  Nenhum evento cadastrado.
+                </p>
+              ) : (
+                <div className={cn("space-y-2")}>
+                  {Object.entries(eventosPorStatus).map(([status, count]) => (
+                    <div
+                      key={status}
+                      className={cn(
+                        "flex items-center justify-between",
+                      )}
+                    >
+                      <Badge
+                        variant={
+                          EVENT_STATUS_VARIANT[status] ?? "outline"
+                        }
+                      >
+                        {EVENT_STATUS_LABEL[status] ?? status}
+                      </Badge>
+                      <span className={cn("text-sm font-bold tabular-nums")}>
+                        {count} evento{count !== 1 ? "s" : ""}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Matrículas */}
+          <Card>
+            <CardHeader>
+              <CardTitle className={cn("flex items-center gap-2")}>
+                <GraduationCap
+                  className={cn("size-4 text-primary")}
+                  aria-hidden="true"
+                />
+                Matrículas
+              </CardTitle>
+              <CardDescription>Total de alunos matriculados.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className={cn("text-3xl font-bold")}>{totalMatriculas}</p>
+              <p className={cn("mt-1 text-xs text-muted-foreground")}>
+                matrícula{totalMatriculas !== 1 ? "s" : ""} ativa
+                {totalMatriculas !== 1 ? "s" : ""}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(cms)/cms/dashboard/relatorios/page.tsx
+++ b/src/app/(cms)/cms/dashboard/relatorios/page.tsx
@@ -1,10 +1,15 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { cn } from "@/lib/utils";
-import { DashboardView } from "./_features/dashboard/view";
+import { RelatoriosView } from "./_features/Relatorios/view";
 
-async function DashboardData() {
+export const metadata: Metadata = {
+  title: "Relatórios — NEXORA CMS",
+};
+
+async function RelatoriosData() {
   const adminClient = createAdminClient();
 
   const now = new Date();
@@ -14,26 +19,14 @@ async function DashboardData() {
   const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
   const [
-    { count: totalEventos },
-    { count: eventosPublicados },
-    { count: totalAdmins },
-    { count: totalAlunos },
     { count: totalAcessos },
     { count: acessosHoje },
     { count: acessosSemana },
     { data: topRecursos, error: topRecursosError },
     { data: logsAtivos },
-    { count: acessosAutenticados },
+    { data: eventos },
+    { count: totalMatriculas },
   ] = await Promise.all([
-    adminClient.from("events").select("*", { count: "exact", head: true }),
-    adminClient
-      .from("events")
-      .select("*", { count: "exact", head: true })
-      .eq("status", "published"),
-    adminClient.from("profiles").select("*", { count: "exact", head: true }),
-    adminClient
-      .from("student_profiles")
-      .select("*", { count: "exact", head: true }),
     adminClient
       .from("access_logs")
       .select("*", { count: "exact", head: true }),
@@ -51,68 +44,69 @@ async function DashboardData() {
       .select("student_id")
       .gte("created_at", monthAgo.toISOString())
       .not("student_id", "is", null),
+    adminClient.from("events").select("status"),
     adminClient
-      .from("access_logs")
-      .select("*", { count: "exact", head: true })
-      .not("student_id", "is", null),
+      .from("enrollments")
+      .select("*", { count: "exact", head: true }),
   ]);
 
   if (topRecursosError) {
-    console.error("[dashboard] get_top_resources rpc error:", topRecursosError);
+    console.error("[relatorios] get_top_resources rpc error:", topRecursosError);
   }
 
   const alunosAtivos = new Set(
     (logsAtivos ?? []).map((l) => l.student_id),
   ).size;
 
+  const eventosPorStatus = (eventos ?? []).reduce<Record<string, number>>(
+    (acc, e) => {
+      acc[e.status] = (acc[e.status] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+
   return (
-    <DashboardView
-      totalEventos={totalEventos ?? 0}
-      eventosPublicados={eventosPublicados ?? 0}
-      totalAdmins={totalAdmins ?? 0}
-      totalAlunos={totalAlunos ?? 0}
+    <RelatoriosView
       totalAcessos={totalAcessos ?? 0}
       acessosHoje={acessosHoje ?? 0}
       acessosSemana={acessosSemana ?? 0}
       alunosAtivos={alunosAtivos}
       topRecursos={topRecursos ?? []}
-      acessosAutenticados={acessosAutenticados ?? 0}
+      eventosPorStatus={eventosPorStatus}
+      totalMatriculas={totalMatriculas ?? 0}
     />
   );
 }
 
-function DashboardLoading() {
+function RelatoriosLoading() {
   return (
     <section
       className={cn("space-y-6")}
-      aria-label="Carregando dashboard"
+      aria-label="Carregando relatórios"
       aria-busy="true"
     >
       <div className={cn("space-y-2")}>
-        <Skeleton className={cn("h-8 w-40")} />
-        <Skeleton className={cn("h-4 w-full max-w-md")} />
+        <Skeleton className={cn("h-7 w-40")} />
+        <Skeleton className={cn("h-4 w-72 max-w-full")} />
       </div>
       <div className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-4")}>
-        <Skeleton className={cn("h-32")} />
-        <Skeleton className={cn("h-32")} />
-        <Skeleton className={cn("h-32")} />
-        <Skeleton className={cn("h-32")} />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className={cn("h-28")} />
+        ))}
       </div>
-      <div className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-4")}>
-        <Skeleton className={cn("h-28")} />
-        <Skeleton className={cn("h-28")} />
-        <Skeleton className={cn("h-28")} />
-        <Skeleton className={cn("h-28")} />
+      <div className={cn("grid gap-6 lg:grid-cols-2")}>
+        <Skeleton className={cn("h-64")} />
+        <Skeleton className={cn("h-64")} />
       </div>
-      <Skeleton className={cn("h-64")} />
     </section>
   );
 }
 
-export default function DashboardPage() {
+export default function RelatoriosPage() {
   return (
-    <Suspense fallback={<DashboardLoading />}>
-      <DashboardData />
+    <Suspense fallback={<RelatoriosLoading />}>
+      <RelatoriosData />
     </Suspense>
   );
 }

--- a/src/app/(cms)/cms/dashboard/tickets/[id]/page.tsx
+++ b/src/app/(cms)/cms/dashboard/tickets/[id]/page.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import TicketAdminChatView from "./_features/view";
 
 export const metadata: Metadata = {
-  title: "Detalhes do Ticket | CMS - NEXORA",
+  title: "Detalhes do Ticket | CMS - NEXORA-TI",
   description: "Visualize e responda ao chamado de suporte.",
 };
 

--- a/src/app/(cms)/cms/dashboard/tickets/page.tsx
+++ b/src/app/(cms)/cms/dashboard/tickets/page.tsx
@@ -2,7 +2,7 @@ import { Inbox } from "lucide-react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Gestão de Tickets | CMS - NEXORA",
+  title: "Gestão de Tickets | CMS - NEXORA-TI",
   description: "Gerencie os tickets de suporte dos alunos.",
 };
 

--- a/src/app/(cms)/cms/login/_features/login/view.tsx
+++ b/src/app/(cms)/cms/login/_features/login/view.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
 import type { ActionState } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import { signIn } from "./actions";
@@ -64,9 +65,8 @@ export function LoginView() {
 
             <div className={cn("space-y-1.5")}>
               <Label htmlFor="password">Senha</Label>
-              <Input
+              <PasswordInput
                 id="password"
-                type="password"
                 placeholder="••••••••"
                 autoComplete="current-password"
                 {...register("password")}
@@ -105,7 +105,7 @@ export function LoginView() {
             "text-4xl font-bold text-primary-foreground tracking-widest",
           )}
         >
-          NEXORA
+          NEXORA-TI
         </span>
       </div>
     </div>

--- a/src/app/(cms)/cms/register/_features/register/view.tsx
+++ b/src/app/(cms)/cms/register/_features/register/view.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
 import type { ActionState } from "@/lib/supabase/types";
 import { cn } from "@/lib/utils";
 import { signUp } from "./actions";
@@ -85,9 +86,8 @@ export function RegisterView() {
 
             <div className={cn("space-y-1.5")}>
               <Label htmlFor="password">Senha</Label>
-              <Input
+              <PasswordInput
                 id="password"
-                type="password"
                 placeholder="••••••••"
                 autoComplete="new-password"
                 {...register("password")}
@@ -106,9 +106,8 @@ export function RegisterView() {
 
             <div className={cn("space-y-1.5")}>
               <Label htmlFor="confirm_password">Confirmar senha</Label>
-              <Input
+              <PasswordInput
                 id="confirm_password"
-                type="password"
                 placeholder="••••••••"
                 autoComplete="new-password"
                 {...register("confirm_password")}
@@ -148,7 +147,7 @@ export function RegisterView() {
             "text-4xl font-bold text-primary-foreground tracking-widest",
           )}
         >
-          NEXORA
+          NEXORA-TI
         </span>
       </div>
     </div>

--- a/src/app/(private)/minha-area/page.tsx
+++ b/src/app/(private)/minha-area/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { logAccess } from "@/lib/analytics/logAccess";
+import { createClient } from "@/lib/supabase/server";
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -8,6 +10,14 @@ export const metadata: Metadata = {
 };
 
 export default async function MinhaAreaPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) {
+    await logAccess({ studentId: user.id, resourceType: "page", resourceSlug: "minha-area" });
+  }
+
   // Mock data: Aqui você fará o fetch dos cursos do aluno no Supabase
   const meusCursos = [
     {

--- a/src/app/(private)/minha-area/perfil/features/view.tsx
+++ b/src/app/(private)/minha-area/perfil/features/view.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PasswordInput } from "@/components/ui/password-input";
 import { getInitials } from "@/utils/getInitials";
 import type { PerfilInitialData } from "./model";
 import { usePerfilViewModel } from "./viewModel";
@@ -143,9 +144,8 @@ export default function PerfilView({ initialData }: PerfilViewProps) {
               >
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="new_password">Nova Senha</Label>
-                  <Input
+                  <PasswordInput
                     id="new_password"
-                    type="password"
                     disabled={isLoadingSenha}
                     {...formSenha.register("new_password")}
                   />
@@ -159,9 +159,8 @@ export default function PerfilView({ initialData }: PerfilViewProps) {
 
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="confirm_password">Confirmar Nova Senha</Label>
-                  <Input
+                  <PasswordInput
                     id="confirm_password"
-                    type="password"
                     disabled={isLoadingSenha}
                     {...formSenha.register("confirm_password")}
                   />

--- a/src/app/(private)/minha-area/tickets/novo/page.tsx
+++ b/src/app/(private)/minha-area/tickets/novo/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import NovoTicketView from "./_features/view";
 
 export const metadata: Metadata = {
-  title: "Novo Ticket | Suporte - NEXORA",
-  description: "Abra um novo ticket de suporte para obter ajuda com a plataforma Nexora.",
+  title: "Novo Ticket | Suporte - NEXORA-TI",
+  description: "Abra um novo ticket de suporte para obter ajuda com a plataforma Nexora-TI.",
 };
 
 export default function NovoTicketPage() {

--- a/src/app/(publics)/(home)/page.tsx
+++ b/src/app/(publics)/(home)/page.tsx
@@ -76,7 +76,7 @@ const testimonials = [
   {
     id: "af",
     quote:
-      "Nunca imaginei que aprenderia a programar. O Portal Nexora tornou isso possível e acessível para mim.",
+      "Nunca imaginei que aprenderia a programar. O Portal Nexora-TI tornou isso possível e acessível para mim.",
     author: "Ana Ferreira",
     role: "Aluna · Empregabilidade em TI",
     avatarInitials: "AF",

--- a/src/app/(publics)/eventos/[slug]/page.tsx
+++ b/src/app/(publics)/eventos/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { logAccess } from "@/lib/analytics/logAccess";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { EventoDetalheView } from "./_features/EventoDetalhe/view";
 
 type PageProps = {
@@ -19,11 +21,11 @@ export async function generateMetadata({
     .single();
 
   if (!data) {
-    return { title: "Evento não encontrado — NEXORA" };
+    return { title: "Evento não encontrado — NEXORA-TI" };
   }
 
   return {
-    title: `${data.title} — NEXORA`,
+    title: `${data.title} — NEXORA-TI`,
     description: data.description,
   };
 }
@@ -42,6 +44,15 @@ export default async function EventoSlugPage({ params }: PageProps) {
   if (!data) {
     notFound();
   }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  await logAccess({
+    studentId: user?.id,
+    resourceType: "event",
+    resourceId: data.id,
+    resourceSlug: data.slug,
+  });
 
   const { data: outros } = await adminClient
     .from("events")

--- a/src/app/(publics)/eventos/_features/eventos/HeroEventos.tsx
+++ b/src/app/(publics)/eventos/_features/eventos/HeroEventos.tsx
@@ -12,7 +12,7 @@ export function HeroEventos() {
             "text-amber-400 text-xs font-semibold tracking-widest uppercase",
           )}
         >
-          Comunidade Nexora
+          Comunidade NEXORA-TI
         </span>
         <h1
           id="eventos-hero-title"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Nexora — Tecnologia que Conecta e Transforma",
+  title: "NEXORA-TI — Tecnologia que Conecta e Transforma",
   description: "Plataforma educacional e serviços de TI com impacto social.",
   icons: {
     icon: "../app/favicon.ico",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -40,7 +40,7 @@ export default function NotFound() {
           )}
         >
           O endereço acessado não existe ou foi movido. Você pode voltar para a
-          página inicial e continuar navegando pelo Portal Nexora.
+          página inicial e continuar navegando pelo Portal NEXORA-TI.
         </p>
 
         <div

--- a/src/components/cms/Sidebar/SidebarNav.tsx
+++ b/src/components/cms/Sidebar/SidebarNav.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import {
-  BookOpen,
   CalendarDays,
-  FileText,
+  GraduationCap,
   LayoutDashboard,
   ShieldCheck,
-  UserCircle,
   TicketIcon,
+  UserCircle,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -34,12 +33,18 @@ const NAV_ITEMS = [
     icon: LayoutDashboard,
     exact: true,
   },
-  { label: "Conteúdos", href: "/cms/contents", icon: FileText, exact: false },
-  { label: "Cursos", href: "/cms/courses", icon: BookOpen, exact: false },
+  // { label: "Conteúdos", href: "/cms/contents", icon: FileText, exact: false },
+  // { label: "Cursos", href: "/cms/courses", icon: BookOpen, exact: false },
   {
     label: "Administradores",
     href: "/cms/dashboard/admins",
     icon: ShieldCheck,
+    exact: false,
+  },
+  {
+    label: "Alunos",
+    href: "/cms/dashboard/alunos",
+    icon: GraduationCap,
     exact: false,
   },
   {
@@ -54,11 +59,11 @@ const NAV_ITEMS = [
     icon: UserCircle,
     exact: false,
   },
-  { 
-    label: "Tickets", 
-    href: "/cms/dashboard/tickets", 
-    icon: TicketIcon, 
-    exact: false 
+  {
+    label: "Tickets",
+    href: "/cms/dashboard/tickets",
+    icon: TicketIcon,
+    exact: false,
   },
 ];
 

--- a/src/components/cms/Sidebar/index.tsx
+++ b/src/components/cms/Sidebar/index.tsx
@@ -54,7 +54,7 @@ export function Sidebar({ user, className }: Props) {
                         "truncate group-data-[state=collapsed]/sidebar:hidden",
                       ])}
                     >
-                      NEXORA CMS
+                      NEXORA-TI CMS
                     </span>
                   </Link>
                 </SidebarMenuButton>

--- a/src/components/cms/TopBar/index.tsx
+++ b/src/components/cms/TopBar/index.tsx
@@ -16,7 +16,7 @@ export function TopBar({ title, mobileNav }: Props) {
       {mobileNav ?? <SidebarTrigger />}
       {title && <h1 className={cn(["text-base font-semibold"])}>{title}</h1>}
       <div className={cn(["ml-auto text-xs text-muted-foreground"])}>
-        NEXORA CMS
+        NEXORA-TI CMS
       </div>
     </header>
   );

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -153,7 +153,7 @@ export async function Header() {
         >
           <SheetHeader className={cn("border-b border-teal-700 p-5")}>
             <SheetTitle className={cn("text-white text-base text-left")}>
-              Nexora
+              Nexora-TI
             </SheetTitle>
           </SheetHeader>
 

--- a/src/components/layout/PrivateSidebar/PrivateSidebar.tsx
+++ b/src/components/layout/PrivateSidebar/PrivateSidebar.tsx
@@ -51,7 +51,7 @@ export function PrivateSidebar({ user, className }: Props) {
                         "truncate group-data-[state=collapsed]/sidebar:hidden",
                       )}
                     >
-                      NEXORA TI
+                      NEXORA-TI
                     </span>
                   </Link>
                 </SidebarMenuButton>

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Eye, EyeOff } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "./input";
+
+type PasswordInputProps = Omit<React.ComponentProps<"input">, "type">;
+
+function PasswordInput({ className, ...props }: PasswordInputProps) {
+  const [show, setShow] = React.useState(false);
+
+  return (
+    <div className={cn("relative")}>
+      <Input
+        type={show ? "text" : "password"}
+        className={cn("pr-9", className)}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setShow((s) => !s)}
+        aria-label={show ? "Ocultar senha" : "Visualizar senha"}
+        tabIndex={-1}
+        className={cn(
+          "absolute right-0 top-0 flex h-9 w-9 items-center justify-center text-muted-foreground transition-colors hover:text-foreground",
+        )}
+      >
+        {show ? (
+          <EyeOff className={cn("size-4")} />
+        ) : (
+          <Eye className={cn("size-4")} />
+        )}
+      </button>
+    </div>
+  );
+}
+
+export { PasswordInput };

--- a/src/databases/00007_fix_auth_trigger_admin.sql
+++ b/src/databases/00007_fix_auth_trigger_admin.sql
@@ -1,0 +1,47 @@
+-- ==============================================================================
+-- MIGRATION: 00007_fix_auth_trigger_admin
+-- Atualiza handle_new_user para não criar student_profiles para admins CMS.
+-- O admin cria seu próprio perfil via INSERT em profiles na action criarAdmin.
+-- ==============================================================================
+
+-- UP
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  IF (NEW.raw_user_meta_data->>'is_cms_admin' IS DISTINCT FROM 'true') THEN
+    INSERT INTO public.student_profiles (id, full_name, email)
+    VALUES (
+      NEW.id,
+      COALESCE(NEW.raw_user_meta_data->>'full_name', ''),
+      NEW.email
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMIT;
+
+-- ==============================================================================
+-- DOWN (reversão)
+-- ==============================================================================
+/*
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.student_profiles (id, full_name, email)
+  VALUES (
+    NEW.id,
+    NEW.raw_user_meta_data->>'full_name',
+    NEW.email
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMIT;
+*/

--- a/src/databases/00008_access_logs.sql
+++ b/src/databases/00008_access_logs.sql
@@ -1,0 +1,52 @@
+-- ==============================================================================
+-- MIGRATION: 00008_access_logs
+-- Sistema de log de acessos para métricas de cursos, eventos e páginas.
+-- Logging é feito server-side via service role — alunos não têm acesso direto.
+-- ==============================================================================
+
+-- UP
+BEGIN;
+
+CREATE TABLE public.access_logs (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  student_id    UUID        REFERENCES public.student_profiles(id) ON DELETE SET NULL,
+  resource_type TEXT        NOT NULL CHECK (resource_type IN ('course', 'event', 'page')),
+  resource_id   UUID,
+  resource_slug TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_access_logs_student_id    ON public.access_logs(student_id);
+CREATE INDEX idx_access_logs_resource_type ON public.access_logs(resource_type);
+CREATE INDEX idx_access_logs_created_at    ON public.access_logs(created_at DESC);
+CREATE INDEX idx_access_logs_resource_id   ON public.access_logs(resource_id)
+  WHERE resource_id IS NOT NULL;
+
+ALTER TABLE public.access_logs ENABLE ROW LEVEL SECURITY;
+-- Sem políticas explícitas: service role bypassa RLS para INSERT/SELECT.
+-- Alunos autenticados não conseguem ler nem escrever diretamente.
+
+-- View para top recursos — consultada pelo dashboard de relatórios via service role.
+CREATE VIEW public.access_log_top_resources AS
+SELECT
+  resource_type,
+  resource_id,
+  resource_slug,
+  COUNT(*)                AS access_count,
+  COUNT(DISTINCT student_id) AS unique_students,
+  MAX(created_at)         AS last_accessed_at
+FROM public.access_logs
+GROUP BY resource_type, resource_id, resource_slug
+ORDER BY access_count DESC;
+
+COMMIT;
+
+-- ==============================================================================
+-- DOWN (reversão)
+-- ==============================================================================
+/*
+BEGIN;
+DROP VIEW  IF EXISTS public.access_log_top_resources;
+DROP TABLE IF EXISTS public.access_logs;
+COMMIT;
+*/

--- a/src/databases/00009_analytics_rpc.sql
+++ b/src/databases/00009_analytics_rpc.sql
@@ -1,0 +1,50 @@
+-- ==============================================================================
+-- MIGRATION: 00009_analytics_rpc
+-- Substitui a VIEW access_log_top_resources por uma função RPC.
+-- Views com GROUP BY + COUNT podem não ser expostas corretamente pelo PostgREST.
+-- Funções SECURITY DEFINER são mais confiáveis para agregações via service role.
+-- ==============================================================================
+
+-- UP
+BEGIN;
+
+DROP VIEW IF EXISTS public.access_log_top_resources;
+
+CREATE OR REPLACE FUNCTION public.get_top_resources(limit_n INT DEFAULT 10)
+RETURNS TABLE (
+  resource_type    TEXT,
+  resource_id      UUID,
+  resource_slug    TEXT,
+  access_count     BIGINT,
+  unique_students  BIGINT,
+  last_accessed_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    resource_type,
+    resource_id,
+    resource_slug,
+    COUNT(*)                   AS access_count,
+    COUNT(DISTINCT student_id) AS unique_students,
+    MAX(created_at)            AS last_accessed_at
+  FROM public.access_logs
+  GROUP BY resource_type, resource_id, resource_slug
+  ORDER BY access_count DESC
+  LIMIT limit_n;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_top_resources(INT) TO service_role;
+
+COMMIT;
+
+-- ==============================================================================
+-- DOWN (reversão)
+-- ==============================================================================
+/*
+BEGIN;
+DROP FUNCTION IF EXISTS public.get_top_resources(INT);
+COMMIT;
+*/

--- a/src/databases/00010_fix_access_logs_student_fk.sql
+++ b/src/databases/00010_fix_access_logs_student_fk.sql
@@ -1,0 +1,26 @@
+-- ==============================================================================
+-- MIGRATION: 00010_fix_access_logs_student_fk
+-- Remove a FK constraint de student_id → student_profiles.
+-- Motivo: usuários sem student_profiles (ex: admins do CMS acessando o portal
+-- público) causavam violação de FK silenciosa. access_logs é uma tabela de
+-- analytics — não precisa de integridade referencial no student_id.
+-- ==============================================================================
+
+-- UP
+BEGIN;
+
+ALTER TABLE public.access_logs
+  DROP CONSTRAINT IF EXISTS access_logs_student_id_fkey;
+
+COMMIT;
+
+-- ==============================================================================
+-- DOWN (reversão)
+-- ==============================================================================
+/*
+BEGIN;
+ALTER TABLE public.access_logs
+  ADD CONSTRAINT access_logs_student_id_fkey
+  FOREIGN KEY (student_id) REFERENCES public.student_profiles(id) ON DELETE SET NULL;
+COMMIT;
+*/

--- a/src/lib/analytics/logAccess.ts
+++ b/src/lib/analytics/logAccess.ts
@@ -1,0 +1,30 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+
+type LogAccessParams = {
+  studentId?: string;
+  resourceType: "course" | "event" | "page";
+  resourceId?: string;
+  resourceSlug?: string;
+};
+
+export async function logAccess({
+  studentId,
+  resourceType,
+  resourceId,
+  resourceSlug,
+}: LogAccessParams): Promise<void> {
+  try {
+    const adminClient = createAdminClient();
+    const { error } = await adminClient.from("access_logs").insert({
+      student_id: studentId ?? null,
+      resource_type: resourceType,
+      resource_id: resourceId ?? null,
+      resource_slug: resourceSlug ?? null,
+    });
+    if (error) {
+      console.error("[logAccess] insert error:", error.message, error.details);
+    }
+  } catch (err) {
+    console.error("[logAccess] unexpected error:", err);
+  }
+}


### PR DESCRIPTION
## Summary

- **PasswordInput**: componente reutilizável com show/hide aplicado em todos os formulários de senha
- **Shadcn Select**: substituição de todos os `<select>` nativos pelo componente Shadcn (padrão `Controller` + `<input type="hidden">`)
- **Fix criação de admin**: reescrita da trigger `handle_new_user()` para ignorar admins CMS via flag `is_cms_admin` no `user_metadata`
- **Sistema de analytics**: tabela `access_logs`, função RPC `get_top_resources`, utilitário `logAccess()` chamado nas páginas de evento e minha-área
- **Fix logs de acesso**: corrigido bug onde Supabase retorna `{ error }` sem lançar exceção (try/catch nunca disparava); removida FK `student_id → student_profiles` que causava violação silenciosa para usuários sem perfil de aluno
- **Dashboard**: 8 cards de métricas, gráfico de barras "Top recursos" e pie chart "Alunos vs Anônimos" com `conic-gradient`
- **Listagem de alunos no CMS**: página `/cms/dashboard/alunos` + card no dashboard
- **Edição de admin via drawer**: Sheet lateral com RHF + Zod + Server Action
- **Relatórios movidos para o dashboard**: item removido do sidebar

## Migrations (rodar no Supabase SQL Editor em ordem)

- `00007_fix_auth_trigger_admin.sql` — corrige trigger de criação de usuário
- `00008_access_logs.sql` — cria tabela `access_logs`
- `00009_analytics_rpc.sql` — cria função RPC `get_top_resources()`
- `00010_fix_access_logs_student_fk.sql` — remove FK constraint problemática

## Test plan

- [ ] Criar novo admin no CMS sem erro de banco
- [ ] Toggle show/hide funciona em todos os campos de senha
- [ ] Selects funcionam nos formulários (novo evento, novo admin)
- [ ] Acessar evento no portal público → verificar inserção em `access_logs`
- [ ] Dashboard exibe métricas e pie chart após rodar as migrations
- [ ] Edição de admin via drawer salva e fecha corretamente
- [ ] Listagem de alunos acessível em `/cms/dashboard/alunos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)